### PR TITLE
Feature/setttings revamp

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [1.5.5]
+### Changed
+- In order to support multiple collections of the same type the check of the `Values` I had to tweak how the instance of every instance its assigned, changed for the `OnEnable` of the collection item
+- Changed the Refresh of the collections to only find items under the same folder.
+- Fixed a lot of scripts to work properly with multiple collections of the same type
+- Added some logs when `CollectionItems` are added/removed from collections to help the visibility
+
+
 ## [1.5.4]
 ### Changed
 - Removed the automatically reload of CollectionRegistry using the `DidReloadScripts` callback, this caused multiple issues on batch mode and on clear libraries
@@ -12,10 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a bunch of validation and verification for the Generation of the static access, making sure it only allows partial classes when is possible and other small checks.
 - The settings are now on the Project Preferences where you can define the default folder for the Scriptable Objects and default namespace.
 - Removed the `ReadOnlyList` on the `Collection`, the casting was expensive and was an unnecessary safety measure
-- In order to support multiple collections of the same type the check of the `Values` I had to tweak how the instance of every instance its assigned, changed for the `OnEnable` of the collection item
-- Changed the Refresh of the collections to only find items under the same folder.
-- Fixed a lot of scripts to work properly with multiple collections of the same type
-- Added some logs when `CollectionItems` are added/removed from collections to help the visibility
+
 
 ## [1.5.3]
 ### Changed
@@ -234,7 +240,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Unreleased
 
 
-
+[1.5.5]: https://github.com/badawe/ScriptableObjectCollection/releases/tag/v1.5.5
 [1.5.4]: https://github.com/badawe/ScriptableObjectCollection/releases/tag/v1.5.4
 [1.5.3]: https://github.com/badawe/ScriptableObjectCollection/releases/tag/v1.5.3
 [1.5.2]: https://github.com/badawe/ScriptableObjectCollection/releases/tag/v1.5.2

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed the Refresh of the collections to only find items under the same folder.
 - Fixed a lot of scripts to work properly with multiple collections of the same type
 - Added some logs when `CollectionItems` are added/removed from collections to help the visibility
-
+- `CollectionType.Values` now will return all the `CollectionItem` available on the registry, so if you have 2 Collections of the one Type this will return the content of both collections while the `CollectionItem.Values` when the access file is generated will only return that specific collection items
 
 ## [1.5.4]
 ### Changed

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactored the `ScriptableObjectSettings` this used to be a Resources object that was auto loaded, but this could also create unwanted dependencies between items. The settings for code generated are not stored inside the Collection itself. Make sure you delete the `ScriptableObjectsSettings` ScriptableObject inside your resources folder.
 - Added a bunch of validation and verification for the Generation of the static access, making sure it only allows partial classes when is possible and other small checks.
 - The settings are now on the Project Preferences where you can define the default folder for the Scriptable Objects and default namespace.
+- Removed the `ReadOnlyList` on the `Collection`, the casting was expensive and was an unnecessary safety measure
+- In order to support multiple collections of the same type the check of the `Values` I had to tweak how the instance of every instance its assigned, changed for the `OnEnable` of the collection item
+- Changed the Refresh of the collections to only find items under the same folder.
+- Fixed a lot of scripts to work properly with multiple collections of the same type
+- Added some logs when `CollectionItems` are added/removed from collections to help the visibility
 
 ## [1.5.3]
 ### Changed

--- a/Scripts/Editor/Core/CollectionCustomEditor.cs
+++ b/Scripts/Editor/Core/CollectionCustomEditor.cs
@@ -35,7 +35,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
         {
             collection = (ScriptableObjectCollection)target;
 
-            if (!CollectionsRegistry.Instance.IsKnowCollectionGUID(collection.GUID))
+            if (!CollectionsRegistry.Instance.IsKnowCollection(collection))
                 CollectionsRegistry.Instance.ReloadCollections();
 
             FixCollectionItems();
@@ -73,6 +73,11 @@ namespace BrunoMikoski.ScriptableObjectCollections
                     collection.ClearBadItems();
                     return;
                 }
+            }
+
+            for (int i = 0; i < collection.Count; i++)
+            {
+                collection[i].SetCollection(collection);
             }
         }
 

--- a/Scripts/Editor/Core/CollectionsAssetsPostProcessor.cs
+++ b/Scripts/Editor/Core/CollectionsAssetsPostProcessor.cs
@@ -62,6 +62,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
                     if (!CollectionsRegistry.Instance.IsKnowCollection(collection))
                     {
                         RefreshRegistry();
+                        Debug.Log($"New collection found on the Project {collection.name}, refreshing the Registry");
                         return;
                     }
                 }

--- a/Scripts/Editor/Core/CollectionsAssetsPostProcessor.cs
+++ b/Scripts/Editor/Core/CollectionsAssetsPostProcessor.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using UnityEditor;
 using UnityEditor.Callbacks;
+using UnityEngine;
 
 namespace BrunoMikoski.ScriptableObjectCollections
 {
@@ -9,32 +10,6 @@ namespace BrunoMikoski.ScriptableObjectCollections
     {
         private const string REFRESH_REGISTRY_AFTER_RECOMPILATION_KEY = "RefreshRegistryAfterRecompilationKey";
 
-        private static Dictionary<Type, ScriptableObjectCollection> cachedTypeToCollections;
-        private static Dictionary<Type, ScriptableObjectCollection> typeToCollections
-        {
-            get
-            {
-                if (cachedTypeToCollections == null)
-                {
-                    cachedTypeToCollections = new Dictionary<Type, ScriptableObjectCollection>();
-                    string[] collectionGUIDS = AssetDatabase.FindAssets($"t:{(nameof(ScriptableObjectCollection))}");
-
-                    foreach (string guid in collectionGUIDS)
-                    {
-                        ScriptableObjectCollection collection =
-                            AssetDatabase.LoadAssetAtPath<ScriptableObjectCollection>(
-                                AssetDatabase.GUIDToAssetPath(guid));
-                        if(collection == null)
-                            continue;
-
-                        cachedTypeToCollections.Add(collection.GetItemType(), collection);
-                    }
-                }
-
-                return cachedTypeToCollections;
-            }
-        }
-        
         private static bool RefreshRegistryAfterRecompilation
         {
             get => EditorPrefs.GetBool(REFRESH_REGISTRY_AFTER_RECOMPILATION_KEY, false);
@@ -59,15 +34,19 @@ namespace BrunoMikoski.ScriptableObjectCollections
                     {
                         if (scriptableObjectCollectionItem.Collection == null)
                         {
-                            if (typeToCollections.TryGetValue(type, out ScriptableObjectCollection collection))
-                            {
-                                if (!collection.Add(scriptableObjectCollectionItem))
-                                    scriptableObjectCollectionItem.SetCollection(collection);
-                            }
+                            Debug.LogError(
+                                $"CollectionItem ({scriptableObjectCollectionItem.name}) has null Collection, please assign it some Collection",
+                                scriptableObjectCollectionItem
+                            );
                         }
                         else
                         {
-                            scriptableObjectCollectionItem.Collection.Add(scriptableObjectCollectionItem);
+                            if (!scriptableObjectCollectionItem.Collection.Contains(scriptableObjectCollectionItem))
+                            {
+                                scriptableObjectCollectionItem.Collection.Add(scriptableObjectCollectionItem);
+                                Debug.Log($"{scriptableObjectCollectionItem.name} has collection assigned "
+                                          + $"{scriptableObjectCollectionItem.Collection} but its missing from collection list, adding it");
+                            }
                         }
                     }
                 }
@@ -80,7 +59,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
                     if (collection == null)
                         continue;
 
-                    if (!CollectionsRegistry.Instance.IsKnowCollectionGUID(collection.GUID))
+                    if (!CollectionsRegistry.Instance.IsKnowCollection(collection))
                     {
                         RefreshRegistry();
                         return;
@@ -98,7 +77,6 @@ namespace BrunoMikoski.ScriptableObjectCollections
             }
 
             EditorApplication.delayCall += () => { CollectionsRegistry.Instance.ReloadCollections(); };
-            
         }
 
 

--- a/Scripts/Runtime/Core/ScriptableObjectCollection.cs
+++ b/Scripts/Runtime/Core/ScriptableObjectCollection.cs
@@ -382,8 +382,8 @@ namespace BrunoMikoski.ScriptableObjectCollections
     public class ScriptableObjectCollection<ObjectType> : ScriptableObjectCollection, IList<ObjectType>
         where ObjectType : ScriptableObjectCollectionItem
     {
-        protected static List<ObjectType> cachedValues;
-        public static List<ObjectType> Values
+        private static List<ObjectType> cachedValues;
+        public static IReadOnlyList<ObjectType> Values
         {
             get
             {

--- a/Scripts/Runtime/Core/ScriptableObjectCollectionItem.cs
+++ b/Scripts/Runtime/Core/ScriptableObjectCollectionItem.cs
@@ -35,6 +35,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
                         CollectionsRegistry.Instance.TryGetCollectionFromItemType(GetType(), out cachedScriptableObjectCollection);
                         if (cachedScriptableObjectCollection != null)
                         {
+                            Debug.Log($"Collection Item ({this.name}) was missing the Collection GUID, assigned to {cachedScriptableObjectCollection.name}");
                             collectionGUID = cachedScriptableObjectCollection.GUID;
                             ObjectUtility.SetDirty(this);
                         }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.brunomikoski.scriptableobjectcollection",
   "displayName": "Scriptable Object Collection",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "unity": "2018.4",
   "description": "A library to help improve the usability of Unity3D Scriptable Objects by grouping then into a collection and exposing then by code or nice inspectors!",
   "keywords": [


### PR DESCRIPTION
### Changed
- In order to support multiple collections of the same type the check of the `Values` I had to tweak how the instance of every instance its assigned, changed for the `OnEnable` of the collection item
- Changed the Refresh of the collections to only find items under the same folder.
- Fixed a lot of scripts to work properly with multiple collections of the same type
- Added some logs when `CollectionItems` are added/removed from collections to help the visibility
- `CollectionType.Values` now will return all the `CollectionItem` available on the registry, so if you have 2 Collections of the one Type this will return the content of both collections while the `CollectionItem.Values` when the access file is generated will only return that specific collection item