### PR TITLE
Change CollectionItemPropertyDrawer to allow customization

### DIFF
--- a/Scripts/Editor/Core/CollectionItemIndirectReferencePropertyDrawer.cs
+++ b/Scripts/Editor/Core/CollectionItemIndirectReferencePropertyDrawer.cs
@@ -12,7 +12,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
         private const string COLLECTION_GUID_PROPERTY_PATh = "collectionGUID";
 
         private Type collectionItemType;
-        private CollectionItemItemPropertyDrawer collectionItemPropertyDrawer;
+        private CollectionItemPropertyDrawer collectionItemPropertyDrawer;
 
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
         {
@@ -25,7 +25,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
 
             if (collectionItemPropertyDrawer == null)
             {
-                collectionItemPropertyDrawer = new CollectionItemItemPropertyDrawer();
+                collectionItemPropertyDrawer = new CollectionItemPropertyDrawer();
                 collectionItemPropertyDrawer.Initialize(collectionItemType, null);
             }
             

--- a/Scripts/Editor/Core/CollectionItemItemPropertyDrawer.cs
+++ b/Scripts/Editor/Core/CollectionItemItemPropertyDrawer.cs
@@ -82,7 +82,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
                     currentObject = collectionItem;
                 
                 DrawEditFoldoutButton(ref prefixPosition, collectionItem);
-                DrawGotoButton(ref prefixPosition);
+                DrawGotoButton(ref prefixPosition, collectionItem);
             }
 
             DrawCollectionItemDropDown(ref prefixPosition, collectionItem, callback);
@@ -182,7 +182,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
             }
         }
 
-        protected virtual void DrawGotoButton(ref Rect popupRect)
+        protected virtual void DrawGotoButton(ref Rect popupRect, ScriptableObjectCollectionItem collectionItem)
         {
             Rect buttonRect = popupRect;
             buttonRect.width = 30;
@@ -191,8 +191,8 @@ namespace BrunoMikoski.ScriptableObjectCollections
             buttonRect.x += popupRect.width;
             if (GUI.Button(buttonRect, CollectionEditorGUI.ARROW_RIGHT_CHAR))
             {
-                Selection.activeObject = item.Collection;
-                CollectionUtility.SetFoldoutOpen(true, this.item, item.Collection);
+                Selection.activeObject = collectionItem.Collection;
+                CollectionUtility.SetFoldoutOpen(true, this.item, collectionItem.Collection);
             }
         }
 

--- a/Scripts/Editor/Core/CollectionItemItemPropertyDrawer.cs
+++ b/Scripts/Editor/Core/CollectionItemItemPropertyDrawer.cs
@@ -14,7 +14,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
 
         private CollectionItemEditorOptionsAttribute cachedOptionsAttribute;
 
-        private CollectionItemEditorOptionsAttribute OptionsAttribute
+        protected CollectionItemEditorOptionsAttribute OptionsAttribute
         {
             get
             {
@@ -68,7 +68,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
                 });
         }
 
-        internal void DrawCollectionItemDrawer(ref Rect position, ScriptableObjectCollectionItem collectionItem, GUIContent label, 
+        public virtual void DrawCollectionItemDrawer(ref Rect position, ScriptableObjectCollectionItem collectionItem, GUIContent label, 
             Action<ScriptableObjectCollectionItem> callback)
         {
             float originY = position.y;
@@ -91,7 +91,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
             totalHeight = position.y - originY;
         }
 
-        private void DrawEditorPreview(ref Rect rect, ScriptableObjectCollectionItem scriptableObjectCollectionItem)
+        protected virtual void DrawEditorPreview(ref Rect rect, ScriptableObjectCollectionItem scriptableObjectCollectionItem)
         {
             if (scriptableObjectCollectionItem == null)
                 return;
@@ -141,7 +141,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
             GUI.Box(boxPosition, GUIContent.none, EditorStyles.helpBox);
         }
 
-        private void Initialize(SerializedProperty property)
+        public virtual void Initialize(SerializedProperty property)
         {
             if (initialized)
                 return;
@@ -149,16 +149,12 @@ namespace BrunoMikoski.ScriptableObjectCollections
             Type arrayOrListType = fieldInfo.FieldType.GetArrayOrListType();
             Type itemType = arrayOrListType != null ? arrayOrListType : fieldInfo.FieldType;
 
-            collectionItemDropdown = new CollectionItemDropdown(
-                new AdvancedDropdownState(),
-                itemType
-            );
+            var obj = property.serializedObject.targetObject;
             
-            currentObject = property.serializedObject.targetObject;
-            initialized = true;
+            Initialize(itemType, obj);
         }
 
-        internal void Initialize(Type collectionItemType, Object obj)
+        public virtual void Initialize(Type collectionItemType, Object obj)
         {
             if (initialized)
                 return;
@@ -172,7 +168,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
             initialized = true;
         }
 
-        private void DrawCollectionItemDropDown(ref Rect position, ScriptableObjectCollectionItem collectionItem,
+        protected virtual void DrawCollectionItemDropDown(ref Rect position, ScriptableObjectCollectionItem collectionItem,
             Action<ScriptableObjectCollectionItem> callback)
         {
             GUIContent displayValue = new GUIContent("None");
@@ -186,7 +182,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
             }
         }
 
-        private void DrawGotoButton(ref Rect popupRect)
+        protected virtual void DrawGotoButton(ref Rect popupRect)
         {
             Rect buttonRect = popupRect;
             buttonRect.width = 30;
@@ -196,11 +192,11 @@ namespace BrunoMikoski.ScriptableObjectCollections
             if (GUI.Button(buttonRect, CollectionEditorGUI.ARROW_RIGHT_CHAR))
             {
                 Selection.activeObject = item.Collection;
-                CollectionUtility.SetFoldoutOpen(true, item, item.Collection);
+                CollectionUtility.SetFoldoutOpen(true, this.item, item.Collection);
             }
         }
 
-        private void DrawEditFoldoutButton(ref Rect popupRect, ScriptableObjectCollectionItem targetItem)
+        protected virtual void DrawEditFoldoutButton(ref Rect popupRect, ScriptableObjectCollectionItem targetItem)
         {
             Rect buttonRect = popupRect;
             buttonRect.width = 30;

--- a/Scripts/Editor/Core/CollectionItemItemPropertyDrawer.cs.meta
+++ b/Scripts/Editor/Core/CollectionItemItemPropertyDrawer.cs.meta
@@ -1,3 +1,0 @@
-﻿fileFormatVersion: 2
-guid: 6cd39f81f71a4f36a4247570e7f59b62
-timeCreated: 1595444833

--- a/Scripts/Editor/Core/CollectionItemPropertyDrawer.cs
+++ b/Scripts/Editor/Core/CollectionItemPropertyDrawer.cs
@@ -7,7 +7,7 @@ using Object = UnityEngine.Object;
 namespace BrunoMikoski.ScriptableObjectCollections
 {
     [CustomPropertyDrawer(typeof(ScriptableObjectCollectionItem), true)]
-    public class CollectionItemItemPropertyDrawer : PropertyDrawer
+    public class CollectionItemPropertyDrawer : PropertyDrawer
     {
         private static readonly CollectionItemEditorOptionsAttribute DefaultAttribute
             = new CollectionItemEditorOptionsAttribute(DrawType.Dropdown);

--- a/Scripts/Editor/Core/CollectionItemPropertyDrawer.cs.meta
+++ b/Scripts/Editor/Core/CollectionItemPropertyDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8b6766a7054182c45a8102b1afaaa225
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Core/CollectionsRegistry.cs
+++ b/Scripts/Runtime/Core/CollectionsRegistry.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using BrunoMikoski.ScriptableObjectCollections.Core;
 using UnityEngine;
+using UnityEngine.Scripting;
 #if UNITY_EDITOR
 using UnityEditor;
 #endif
@@ -15,6 +16,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
         [SerializeField]
         private List<ScriptableObjectCollection> collections = new List<ScriptableObjectCollection>();
 
+        [Preserve]
         public void UsedOnlyForAOTCodeGeneration()
         {
             LoadOrCreateInstance<CollectionsRegistry>();


### PR DESCRIPTION
Changes:
- [aa1eaa7] Change CollectionItemItemPropertyDrawer to CollectionItemPropertyDrawer
- [1245828] Change DrawGotoButton to use the same parameters as DrawEditFoldoutButton
- [11bf7bd] Change PropertyDrawers to be protected & virtual for further customization

Minor:
- [405d6b7] Add preserve to AoT helper code, so that it survives code stripping