### PR TITLE
More collection item editor options

### DIFF
--- a/Scripts/Editor/Core/CollectionItemIndirectReferencePropertyDrawer.cs
+++ b/Scripts/Editor/Core/CollectionItemIndirectReferencePropertyDrawer.cs
@@ -12,7 +12,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
         private const string COLLECTION_GUID_PROPERTY_PATh = "collectionGUID";
 
         private Type collectionItemType;
-        private CollectionItemItemPropertyDrawer collectionItemPropertyDrawer;
+        private CollectionItemPropertyDrawer collectionItemPropertyDrawer;
 
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
         {
@@ -25,7 +25,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
 
             if (collectionItemPropertyDrawer == null)
             {
-                collectionItemPropertyDrawer = new CollectionItemItemPropertyDrawer();
+                collectionItemPropertyDrawer = new CollectionItemPropertyDrawer();
                 collectionItemPropertyDrawer.Initialize(collectionItemType, null);
             }
             

--- a/Scripts/Editor/Core/CollectionItemItemPropertyDrawer.cs
+++ b/Scripts/Editor/Core/CollectionItemItemPropertyDrawer.cs
@@ -82,7 +82,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
                     currentObject = collectionItem;
                 
                 DrawEditFoldoutButton(ref prefixPosition, collectionItem);
-                DrawGotoButton(ref prefixPosition);
+                DrawGotoButton(ref prefixPosition, collectionItem);
             }
 
             DrawCollectionItemDropDown(ref prefixPosition, collectionItem, callback);
@@ -149,13 +149,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
             Type arrayOrListType = fieldInfo.FieldType.GetArrayOrListType();
             Type itemType = arrayOrListType != null ? arrayOrListType : fieldInfo.FieldType;
 
-            collectionItemDropdown = new CollectionItemDropdown(
-                new AdvancedDropdownState(),
-                itemType
-            );
-            
-            currentObject = property.serializedObject.targetObject;
-            initialized = true;
+            Initialize(itemType, property.serializedObject.targetObject);
         }
 
         internal void Initialize(Type collectionItemType, Object obj)
@@ -186,7 +180,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
             }
         }
 
-        private void DrawGotoButton(ref Rect popupRect)
+        private void DrawGotoButton(ref Rect popupRect, ScriptableObjectCollectionItem collectionItem)
         {
             Rect buttonRect = popupRect;
             buttonRect.width = 30;
@@ -195,8 +189,8 @@ namespace BrunoMikoski.ScriptableObjectCollections
             buttonRect.x += popupRect.width;
             if (GUI.Button(buttonRect, CollectionEditorGUI.ARROW_RIGHT_CHAR))
             {
-                Selection.activeObject = item.Collection;
-                CollectionUtility.SetFoldoutOpen(true, item, item.Collection);
+                Selection.activeObject = collectionItem.Collection;
+                CollectionUtility.SetFoldoutOpen(true, item, collectionItem.Collection);
             }
         }
 

--- a/Scripts/Editor/Core/CollectionItemItemPropertyDrawer.cs.meta
+++ b/Scripts/Editor/Core/CollectionItemItemPropertyDrawer.cs.meta
@@ -1,3 +1,0 @@
-﻿fileFormatVersion: 2
-guid: 6cd39f81f71a4f36a4247570e7f59b62
-timeCreated: 1595444833

--- a/Scripts/Editor/Core/CollectionItemPropertyDrawer.cs
+++ b/Scripts/Editor/Core/CollectionItemPropertyDrawer.cs
@@ -189,7 +189,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
             if (GUI.Button(buttonRect, CollectionEditorGUI.ARROW_RIGHT_CHAR))
             {
                 Selection.activeObject = collectionItem.Collection;
-                CollectionUtility.SetFoldoutOpen(true, item, collectionItem.Collection);
+                CollectionUtility.SetFoldoutOpen(true, collectionItem, collectionItem.Collection);
             }
         }
 

--- a/Scripts/Editor/Core/CollectionItemPropertyDrawer.cs
+++ b/Scripts/Editor/Core/CollectionItemPropertyDrawer.cs
@@ -7,7 +7,7 @@ using Object = UnityEngine.Object;
 namespace BrunoMikoski.ScriptableObjectCollections
 {
     [CustomPropertyDrawer(typeof(ScriptableObjectCollectionItem), true)]
-    public class CollectionItemItemPropertyDrawer : PropertyDrawer
+    public class CollectionItemPropertyDrawer : PropertyDrawer
     {
         private static readonly CollectionItemEditorOptionsAttribute DefaultAttribute
             = new CollectionItemEditorOptionsAttribute(DrawType.Dropdown);

--- a/Scripts/Editor/Core/CollectionItemPropertyDrawer.cs
+++ b/Scripts/Editor/Core/CollectionItemPropertyDrawer.cs
@@ -147,7 +147,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
             OptionsAttribute = optionsAttribute ?? GetOptionsAttribute();
         }
 
-        internal virtual void Initialize(Type collectionItemType, Object obj)
+        internal void Initialize(Type collectionItemType, Object obj)
         {
             if (initialized)
                 return;

--- a/Scripts/Editor/Core/CollectionItemPropertyDrawer.cs
+++ b/Scripts/Editor/Core/CollectionItemPropertyDrawer.cs
@@ -144,7 +144,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
         internal void Initialize(Type collectionItemType, CollectionItemEditorOptionsAttribute optionsAttribute)
         {
             Initialize(collectionItemType, (Object)null);
-            OptionsAttribute = optionsAttribute;
+            OptionsAttribute = optionsAttribute ?? GetOptionsAttribute();
         }
 
         internal virtual void Initialize(Type collectionItemType, Object obj)

--- a/Scripts/Editor/Core/CollectionItemPropertyDrawer.cs.meta
+++ b/Scripts/Editor/Core/CollectionItemPropertyDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6cd39f81f71a4f36a4247570e7f59b62
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Core/CollectionItemEditorOptionsAttribute.cs
+++ b/Scripts/Runtime/Core/CollectionItemEditorOptionsAttribute.cs
@@ -7,20 +7,23 @@ namespace BrunoMikoski.ScriptableObjectCollections
         Dropdown = 0,
         AsReference = 1
     }
-    
-    [AttributeUsage(AttributeTargets.Field)]
-    public class CollectionItemEditorOptionsAttribute :Attribute
+
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Class)]
+    public class CollectionItemEditorOptionsAttribute : Attribute
     {
-        private DrawType drawType = DrawType.Dropdown;
-        public DrawType DrawType
+        public DrawType DrawType { get; set; } = DrawType.Dropdown;
+
+        public bool ShouldDrawGotoButton { get; set; } = true;
+
+        public bool ShouldDrawPreviewButton { get; set; } = true;
+
+        public CollectionItemEditorOptionsAttribute()
         {
-            get => drawType;
-            set => drawType = value;
         }
 
         public CollectionItemEditorOptionsAttribute(DrawType drawType)
         {
-            this.drawType = drawType;
+            DrawType = drawType;
         }
     }
 }

--- a/Scripts/Runtime/Core/CollectionsRegistry.cs
+++ b/Scripts/Runtime/Core/CollectionsRegistry.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using BrunoMikoski.ScriptableObjectCollections.Core;
 using UnityEngine;
+using UnityEngine.Scripting;
 #if UNITY_EDITOR
 using UnityEditor;
 #endif
@@ -15,6 +16,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
         [SerializeField]
         private List<ScriptableObjectCollection> collections = new List<ScriptableObjectCollection>();
 
+        [Preserve]
         public void UsedOnlyForAOTCodeGeneration()
         {
             LoadOrCreateInstance<CollectionsRegistry>();

--- a/Scripts/Runtime/Core/CollectionsRegistry.cs
+++ b/Scripts/Runtime/Core/CollectionsRegistry.cs
@@ -13,7 +13,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
     [DefaultExecutionOrder(-1000)]
     public class CollectionsRegistry : ResourceScriptableObjectSingleton<CollectionsRegistry>
     {
-        [SerializeField]
+        [SerializeField] 
         private List<ScriptableObjectCollection> collections = new List<ScriptableObjectCollection>();
 
         [Preserve]
@@ -58,7 +58,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
 
         public List<T> GetAllCollectionItemsOfType<T>() where T : ScriptableObjectCollectionItem
         {
-            return GetAllCollectionItemsOfType(typeof(T)).Cast<T>().ToList();
+            return GetAllCollectionItemsOfType(typeof(T)).OfType<T>().ToList();
         }
 
         public List<ScriptableObjectCollectionItem> GetAllCollectionItemsOfType(Type itemType)
@@ -75,7 +75,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
 
             return results;
         }
-        
+
         public List<ScriptableObjectCollection> GetCollectionsByItemType<T>() where T : ScriptableObjectCollectionItem
         {
             return GetCollectionsByItemType(typeof(T));
@@ -96,7 +96,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
 
             return result;
         }
-        
+
         public ScriptableObjectCollection GetCollectionByGUID(string guid)
         {
             for (int i = 0; i < collections.Count; i++)
@@ -170,7 +170,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
             scriptableObjectCollection = null;
             return false;
         }
-        
+
         public bool TryGetCollectionByGUID(string targetGUID, out ScriptableObjectCollection resultCollection)
         {
             for (int i = 0; i < collections.Count; i++)
@@ -296,14 +296,14 @@ namespace BrunoMikoski.ScriptableObjectCollections
         {
             ReloadCollections();
         }
-        
+
 #if UNITY_EDITOR
         public void PrepareForPlayMode()
         {
             for (int i = 0; i < collections.Count; i++)
                 collections[i].PrepareForPlayMode();
         }
-        
+
         public void PrepareForEditorMode()
         {
             for (int i = 0; i < collections.Count; i++)

--- a/Scripts/Runtime/Core/ResourceScriptableObjectSingleton.cs
+++ b/Scripts/Runtime/Core/ResourceScriptableObjectSingleton.cs
@@ -17,17 +17,17 @@ namespace BrunoMikoski.ScriptableObjectCollections.Core
         }
 
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
-        public static T LoadOrCreateInstance<T>() where T : ScriptableObject
+        public static TInstance LoadOrCreateInstance<TInstance>() where TInstance : ScriptableObject
         {
-            if (!TryToLoadInstance<T>(out T resultInstance))
+            if (!TryToLoadInstance<TInstance>(out TInstance resultInstance))
             {
 #if !UNITY_EDITOR
                 return null;
 #else
-                resultInstance = CreateInstance<T>();
+                resultInstance = CreateInstance<TInstance>();
 
                 AssetDatabaseUtils.CreatePathIfDontExist("Assets/Resources");
-                UnityEditor.AssetDatabase.CreateAsset(resultInstance, $"Assets/Resources/{typeof(T).Name}.asset");
+                UnityEditor.AssetDatabase.CreateAsset(resultInstance, $"Assets/Resources/{typeof(TInstance).Name}.asset");
                 UnityEditor.AssetDatabase.SaveAssets();
                 UnityEditor.AssetDatabase.Refresh();
                 return resultInstance;
@@ -42,9 +42,9 @@ namespace BrunoMikoski.ScriptableObjectCollections.Core
             return TryToLoadInstance<T>(out _);
         }
 
-        private static bool TryToLoadInstance<T>(out T result) where T: ScriptableObject
+        private static bool TryToLoadInstance<TInstance>(out TInstance result) where TInstance: ScriptableObject
         {
-            T newInstance = Resources.Load<T>(typeof(T).Name);
+            TInstance newInstance = Resources.Load<TInstance>(typeof(TInstance).Name);
 
             if (newInstance != null)
             {
@@ -53,12 +53,12 @@ namespace BrunoMikoski.ScriptableObjectCollections.Core
             }
 
 #if UNITY_EDITOR
-            string registryGUID = UnityEditor.AssetDatabase.FindAssets($"t:{typeof(T).Name}")
+            string registryGUID = UnityEditor.AssetDatabase.FindAssets($"t:{typeof(TInstance).Name}")
                 .FirstOrDefault();
 
             if (!string.IsNullOrEmpty(registryGUID))
             {
-                newInstance = (T) UnityEditor.AssetDatabase.LoadAssetAtPath<ScriptableObject>(
+                newInstance = (TInstance) UnityEditor.AssetDatabase.LoadAssetAtPath<ScriptableObject>(
                     UnityEditor.AssetDatabase.GUIDToAssetPath(registryGUID));
             }
 


### PR DESCRIPTION
**Changes**
- Add shouldDrawGotoButton and shouldDrawPreviewButton to CollectionItemEditorOptions, use auto-properties
- Added OptionsAttribute getting and passing through to CollectionItemPropertyDrawer

- Changed CollectionItemPropertyDrawer to allow for OptionsAttribute to be provided in constructor
- Refactored CollectionItemIndirectReferencePropertyDrawer OnGUI into subfunctions for readability

- Change DrawGotoButton to use the same parameters as DrawEditFoldoutButton
- Renamed CollectionItemItemPropertyDrawer to CollectionItemPropertyDrawer

**Unrelated to Expanded Options:**
- Fix T is also used as the Type variable of the class by using TInstance instead of T (+5 squashed commit)
- Add [Preserve] to AoT helper code, so that it survives code stripping