### PR TITLE
Added skipping collection if it already is registered

### DIFF
--- a/Scripts/Runtime/Core/CollectionsRegistry.cs
+++ b/Scripts/Runtime/Core/CollectionsRegistry.cs
@@ -217,6 +217,9 @@ namespace BrunoMikoski.ScriptableObjectCollections
                     if (collection == null)
                         continue;
 
+                    if (collections.Contains(collection))
+                        continue;
+
                     collection.RefreshCollection();
                     collections.Add(collection);
                     changed = true;


### PR DESCRIPTION
Assuming that we have a `TestCollection` which is a `ScriptableObjectCollection<Test>` 
The `TypeCache` can find these two types:
- `TestCollection`
- `ScriptableObjectCollection<Test>`

Even though these are the same object, and they will both be added to the collections list, which will prevent you from generating code.