### PR TITLE
Feature/add references

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ There's a couple of ways of dealing with this, the easiest one is to use the `In
 Since the CollectionsRegistry is inside the Resources folder, every reference this has to a collection and to all the collectables will be inside the Unity Resources bundle, and if you have a lot of references for expensive stuff, this can increase your startup time significantly, there are 2 things you should keep in mind: 
 1. Use the Automatically Loaded items for items that should be available for the lifetime of your game
 2. If you want to use this for more expensive stuff, let's say all the gameplay prefabs, you can uncheck the automatic initialization of this collection, and register the collection on your loading by using `CollectionsRegistry.Instance.RegisterCollection(Collection);` and removing it when they are not necessary anymore.
+3. You can convert the items of a collection to references by using the "Convert To References" button in the collection inspector. This allows for more flexibility to load and unload items individually. These items are inserted into an Addressables group.
 </details>
  
  <details>

--- a/Scripts/Editor/BrunoMikoski.ScriptableObjectCollection.Editor.asmdef
+++ b/Scripts/Editor/BrunoMikoski.ScriptableObjectCollection.Editor.asmdef
@@ -1,7 +1,9 @@
 {
     "name": "BrunoMikoski.ScriptableObjectCollection.Editor",
+    "rootNamespace": "",
     "references": [
-        "BrunoMikoski.ScriptableObjectCollection"
+        "BrunoMikoski.ScriptableObjectCollection",
+        "Unity.Addressables.Editor"
     ],
     "includePlatforms": [
         "Editor"
@@ -12,6 +14,12 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.addressables",
+            "expression": "1.0.0",
+            "define": "SOC_ADDRESSABLES"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/Scripts/Editor/Core/CollectionCustomEditor.cs
+++ b/Scripts/Editor/Core/CollectionCustomEditor.cs
@@ -207,7 +207,8 @@ namespace BrunoMikoski.ScriptableObjectCollections
                         GUI.enabled = guiEnabled;
                         rect.y += EditorGUIUtility.singleLineHeight + EditorGUIUtility.standardVerticalSpacing;
                     }
-                    else 
+                    else
+                    {
                         for (bool enterChildren = true; iterator.NextVisible(enterChildren); enterChildren = false)
                         {
                             bool guiEnabled = GUI.enabled;
@@ -217,8 +218,10 @@ namespace BrunoMikoski.ScriptableObjectCollections
                             EditorGUI.PropertyField(rect, iterator, true);
                             GUI.enabled = guiEnabled;
 
-                            rect.y += EditorGUI.GetPropertyHeight(iterator, true) + EditorGUIUtility.standardVerticalSpacing;
+                            rect.y += EditorGUI.GetPropertyHeight(iterator, true) +
+                                      EditorGUIUtility.standardVerticalSpacing;
                         }
+                    }
 
                     if (changeCheck.changed)
                         iterator.serializedObject.ApplyModifiedProperties();

--- a/Scripts/Editor/Core/CollectionCustomEditor.cs
+++ b/Scripts/Editor/Core/CollectionCustomEditor.cs
@@ -55,7 +55,6 @@ namespace BrunoMikoski.ScriptableObjectCollections
             CheckGeneratedCodeLocation();
             CheckIfCanBePartial();
             CheckGeneratedStaticFileName();
-            CheckGeneratedStaticFileNamespace();
             editorInstance = this;
         }
 
@@ -767,26 +766,6 @@ namespace BrunoMikoski.ScriptableObjectCollections
                 fileNameSerializedProperty.stringValue = $"{collection.name}Static".Sanitize().FirstToUpper();
             }
             fileNameSerializedProperty.serializedObject.ApplyModifiedProperties();
-        }
-        
-        private void CheckGeneratedStaticFileNamespace()
-        {
-            SerializedProperty fileNamespaceSerializedProperty = serializedObject.FindProperty("generateStaticFileNamespace");
-            if (!string.IsNullOrEmpty(fileNamespaceSerializedProperty.stringValue))
-                return;
-            
-            
-            ScriptableObjectCollectionSettings settingsInstance = ScriptableObjectCollectionSettings.GetInstance();
-            if (!string.IsNullOrEmpty(settingsInstance.NamespacePrefix))
-            {
-                fileNamespaceSerializedProperty.stringValue = settingsInstance.NamespacePrefix;
-                fileNamespaceSerializedProperty.serializedObject.ApplyModifiedProperties();
-                return;
-            }
-
-
-            fileNamespaceSerializedProperty.stringValue = collection.GetItemType().Namespace;
-            fileNamespaceSerializedProperty.serializedObject.ApplyModifiedProperties();
         }
 
         private bool CheckIfCanBePartial()

--- a/Scripts/Editor/Core/CollectionsAssetsPostProcessor.cs
+++ b/Scripts/Editor/Core/CollectionsAssetsPostProcessor.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using UnityEditor;
 using UnityEditor.Callbacks;
 using UnityEngine;
@@ -41,7 +40,8 @@ namespace BrunoMikoski.ScriptableObjectCollections
                         }
                         else
                         {
-                            if (!scriptableObjectCollectionItem.Collection.Contains(scriptableObjectCollectionItem))
+                            if (!scriptableObjectCollectionItem.Collection.Contains(scriptableObjectCollectionItem) && 
+                                !scriptableObjectCollectionItem.Collection.ContainsReferenceTo(scriptableObjectCollectionItem))
                             {
                                 scriptableObjectCollectionItem.Collection.Add(scriptableObjectCollectionItem);
                                 Debug.Log($"{scriptableObjectCollectionItem.name} has collection assigned "

--- a/Scripts/Editor/Core/ReferenceConverter.cs
+++ b/Scripts/Editor/Core/ReferenceConverter.cs
@@ -296,7 +296,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
                 item.SetCollection(collectionItem.Collection);
                 if (!item.TryGetReference(out var referenceItem))
                     throw new Exception("Something went wrong!");
-                referenceItem.targetGuid = collectionItem.GUID;
+                referenceItem.TargetGuid = collectionItem.GUID;
                 
                 string referencesDirectory = Path.Combine(baseDirectory.ToString(), "References");
                 Directory.CreateDirectory(referencesDirectory);

--- a/Scripts/Editor/Core/ReferenceConverter.cs
+++ b/Scripts/Editor/Core/ReferenceConverter.cs
@@ -1,0 +1,307 @@
+#if SOC_ADDRESSABLES
+using System;
+using System.IO;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using UnityEditor;
+using UnityEditor.AddressableAssets;
+using UnityEditor.AddressableAssets.Settings;
+using UnityEditor.AddressableAssets.Settings.GroupSchemas;
+using UnityEditor.Callbacks;
+using UnityEditor.Compilation;
+using UnityEditorInternal;
+using UnityEngine;
+
+namespace BrunoMikoski.ScriptableObjectCollections
+{
+    internal static class ReferenceConverter
+    {
+        private const string REFERENCE_QUALIFIED_CLASS_KEY = "SessionReferenceAssemblyQualifiedClassName";
+        private const string BASE_CLASS_KEY = "SessionBaseClassName";
+        internal const string BaseClassNamePostFix = "Base";
+        internal static void StartProcess(ReorderableList reorderableList)
+        {
+            try
+            {
+                StartProcessInternal(reorderableList);
+            }
+            catch (Exception e)
+            {
+                Debug.LogError($"Failed to convert items to references! {e}");
+                EditorUtility.ClearProgressBar();
+                SessionState.SetBool(CollectionCustomEditor.ENABLE_GUI_KEY, true);
+                throw;
+            }
+        }
+        internal static void StartProcessInternal(ReorderableList reorderableList)
+        {
+            if (reorderableList.count == 0) throw new Exception("Collection is empty!");
+            ShowProgressBar("Reloading collections...", 0.1f);
+            CollectionsRegistry.Instance.ReloadCollections();
+            string referenceClassQualifiedName;
+            string baseClassName;
+            AssetDatabase.StartAssetEditing();
+            try
+            {
+                ShowProgressBar("Creating base and reference class...", 0.2f);
+                baseClassName = CreateItemBaseClass(reorderableList);
+                SerializedProperty property = reorderableList.serializedProperty.GetArrayElementAtIndex(0);
+                referenceClassQualifiedName = CreateReferenceClass(baseClassName, property);
+            }
+            finally
+            {
+                AssetDatabase.StopAssetEditing();
+            }
+            AssetDatabase.SaveAssets();
+            AssetDatabase.Refresh(ImportAssetOptions.ForceUpdate);
+            SessionState.SetString(REFERENCE_QUALIFIED_CLASS_KEY, referenceClassQualifiedName);
+            SessionState.SetString(BASE_CLASS_KEY, baseClassName);
+            // Player scripts recompilation is required to be able to use the newly created classes
+            ShowProgressBar("Recompiling player scripts...", 0.3f);
+            CompilationPipeline.RequestScriptCompilation();
+        }
+        
+        private static string CreateItemBaseClass(ReorderableList reorderableList)
+        {
+            if (reorderableList.count == 0) throw new Exception("Collection is empty!");
+            SerializedProperty property = reorderableList.serializedProperty.GetArrayElementAtIndex(0);
+            string classNamespace = property.objectReferenceValue.GetType().Namespace;
+            (string scriptPath, string scriptName) = GetAssociatedScriptMetaData(new SerializedObject(property.objectReferenceValue));
+            string parentFolder = Directory.GetParent(scriptPath)?.ToString();
+            string baseClassName = $"{scriptName}{BaseClassNamePostFix}";
+            
+            string baseClassPath = $"{parentFolder}/{baseClassName}.cs";
+            if (File.Exists(baseClassPath)) File.Delete(baseClassPath);
+            bool result = CodeGenerationUtility.CreateNewEmptyScript(baseClassName,
+                parentFolder,
+                classNamespace,
+                "",
+                $"public abstract class {baseClassName} : {nameof(ScriptableObjectCollectionItem)}", 
+                null, 
+                property.objectReferenceValue.GetType().Namespace, "BrunoMikoski.ScriptableObjectCollections");
+            if (!result)
+            {
+                throw new Exception($"Failed to create item base class \"{baseClassName}.cs\"!");
+            }
+
+            return baseClassName;
+        }
+        
+        private static string CreateReferenceClass(string baseClassName, SerializedProperty property)
+        {
+            string classNamespace = property.objectReferenceValue.GetType().Namespace;
+            (string scriptPath, string scriptName) = GetAssociatedScriptMetaData(new SerializedObject(property.objectReferenceValue));
+            string parentFolder = Directory.GetParent(scriptPath)?.ToString();
+            string itemClassName = scriptName;
+            string className = $"{itemClassName}Reference";
+            
+            string referenceClassPath = $"{parentFolder}/{className}.cs";
+            if (File.Exists(referenceClassPath)) File.Delete(referenceClassPath);
+            bool result = CodeGenerationUtility.CreateNewEmptyScript(className,
+                parentFolder,
+                classNamespace,
+                "",
+                $"public class {className} : {baseClassName}", 
+                CodeGenerationUtility.ReferenceClassCode(itemClassName),
+                property.objectReferenceValue.GetType().Namespace, "BrunoMikoski.ScriptableObjectCollections", 
+                "UnityEngine", "System.Threading.Tasks");
+            if (!result)
+            {
+                throw new Exception($"Failed to create item base class \"{className}.cs\"!");
+            }
+
+            if (!string.IsNullOrEmpty(classNamespace))
+            {
+                itemClassName = $"{classNamespace}.{itemClassName}";
+                className = $"{classNamespace}.{className}";
+            }
+
+            string qualifiedName = property.objectReferenceValue.GetType().AssemblyQualifiedName;
+            string[] typeProperties = qualifiedName?.Split(',');
+            if (typeProperties != null && typeProperties.Length >= 1) typeProperties[0] = typeProperties[0].Replace(itemClassName, className);
+            return String.Join(",", typeProperties);
+        }
+
+        [DidReloadScripts]
+        private static async void OnScriptReload()
+        {
+            string referenceClassName = SessionState.GetString(REFERENCE_QUALIFIED_CLASS_KEY, string.Empty);
+            string baseClassName = SessionState.GetString(BASE_CLASS_KEY, string.Empty);
+            if (String.IsNullOrEmpty(referenceClassName) || String.IsNullOrEmpty(baseClassName)) return;
+            SessionState.EraseString(REFERENCE_QUALIFIED_CLASS_KEY);
+            SessionState.EraseString(BASE_CLASS_KEY);
+
+            while (CollectionCustomEditor.editorInstance == null)
+            {
+                await Task.Delay(100);
+            }
+            EditorApplication.delayCall += () =>
+                ResumeReferencesConversion(CollectionCustomEditor.editorInstance, referenceClassName, baseClassName);
+        }
+
+        private static void ResumeReferencesConversion(CollectionCustomEditor collectionEditor, string referenceClassQualifiedName, string baseClassName)
+        {
+            try
+            {
+                ConvertToReferenceItems(collectionEditor, referenceClassQualifiedName, baseClassName);
+            }
+            catch (Exception e)
+            {
+                Debug.LogError($"Failed to convert items to references! {e}");
+                throw;
+            }
+            finally
+            {
+                SessionState.SetBool(CollectionCustomEditor.ENABLE_GUI_KEY, true);
+                EditorUtility.ClearProgressBar();
+            }
+        }
+        
+        private static void ConvertToReferenceItems(CollectionCustomEditor collectionEditor, string referenceClassQualifiedName, string baseClassName)
+        {
+            ShowProgressBar("Creating references...", 0.6f);
+            SerializedProperty itemProperty =
+                collectionEditor.ReorderableList.serializedProperty.GetArrayElementAtIndex(0);
+            string actualItemType = itemProperty.objectReferenceValue.GetType().ToString();
+            AssetDatabase.StartAssetEditing();
+            try
+            {
+                UpdateInheritanceOfItemClass(collectionEditor.ReorderableList);
+                ConvertToReferencesItemsInternal(collectionEditor.ReorderableList, referenceClassQualifiedName);
+            }
+            finally
+            {
+                AssetDatabase.StopAssetEditing();
+            }
+            ShowProgressBar("Regenerating collection and static class...", 0.8f);
+            AssetDatabase.SaveAssets();
+            collectionEditor.ReorderableList.serializedProperty.serializedObject.ApplyModifiedProperties();
+
+            UpdateInheritanceOfCollectionClass(baseClassName, actualItemType, collectionEditor);
+            CodeGenerationUtility.GenerateStaticCollectionScript(collectionEditor.Collection);
+            
+            ShowProgressBar("Conversion Complete!", 1.0f);
+            EditorUtility.ClearProgressBar();
+        }
+
+        private static void UpdateInheritanceOfItemClass(ReorderableList reorderableList)
+        {
+            SerializedProperty property = reorderableList.serializedProperty.GetArrayElementAtIndex(0);
+            (string scriptPath, string scriptName) = GetAssociatedScriptMetaData(new SerializedObject(property.objectReferenceValue));
+            string className = scriptName;
+            string baseClassName = $"{scriptName}{BaseClassNamePostFix}";
+            string regexPattern =
+                @$"(class\s+{className}\s+:\s+)({nameof(ScriptableObjectCollectionItem)})";
+            string updatedFileContents = new Regex(regexPattern).Replace(File.ReadAllText(scriptPath), $"$1{baseClassName}", 1);
+            File.WriteAllText(scriptPath, updatedFileContents);
+        }
+
+        private static (string path, string name) GetAssociatedScriptMetaData(SerializedObject itemObject)
+        {
+            UnityEngine.Object scriptProperty = itemObject.FindProperty("m_Script").objectReferenceValue;
+            if (!AssetDatabase.TryGetGUIDAndLocalFileIdentifier(scriptProperty, out string scriptGuid, out long _))
+                throw new Exception($"Failed to convert to references. This collection does not have an associated script!");
+            return (AssetDatabase.GUIDToAssetPath(scriptGuid), scriptProperty.name);
+        }
+
+        private static void UpdateInheritanceOfCollectionClass(string baseClassName, string actualItemType, CollectionCustomEditor collectionEditor)
+        {
+            (string scriptPath, string scriptName) = GetAssociatedScriptMetaData(collectionEditor.serializedObject);
+            string fileName = Path.GetFileNameWithoutExtension(scriptPath);
+            string className = scriptName;
+            string regexPattern =
+                @$"(class\s+{className}\s+:\s+{nameof(ScriptableObjectCollection)})(<{actualItemType}>)";
+            
+            string updatedFileContents = new Regex(regexPattern).Replace(File.ReadAllText(scriptPath), $"$1<{baseClassName}>", 1);
+            if (!updatedFileContents.Contains(baseClassName))
+            {
+                Debug.Log($"Could not match regex pattern to substitute base class of the collection {fileName}! Recreating collection class..");
+                RecreateCollectionClass(baseClassName, collectionEditor.Collection, collectionEditor.serializedObject);
+                return;
+            }
+            File.WriteAllText(scriptPath, updatedFileContents);
+        }
+        
+        
+        private static void RecreateCollectionClass(string baseClassName, ScriptableObjectCollection collection, SerializedObject serializedObject)
+        {
+            string classNamespace = collection.GetType().Namespace;
+            (string scriptPath, string _) = GetAssociatedScriptMetaData(serializedObject);
+            string parentFolder = Directory.GetParent(scriptPath)?.ToString();
+            string fileName = Path.GetFileNameWithoutExtension(scriptPath);
+            
+            File.Delete(scriptPath);
+            bool result = CodeGenerationUtility.CreateNewEmptyScript(fileName,
+                parentFolder,
+                classNamespace,
+                $"[CreateAssetMenu(menuName = \"ScriptableObject Collection/Collections/Create {fileName}\", fileName = \"{fileName}\", order = 0)]",
+                $"public class {fileName} : ScriptableObjectCollection<{baseClassName}>", 
+                null, 
+                typeof(ScriptableObjectCollection).Namespace, "UnityEngine", "System.Collections.Generic");
+            if (!result)
+            {
+                throw new Exception($"Failed to create collection class \"{collection.name}.cs\"!");
+            }
+        }
+        
+        private static void ConvertToReferencesItemsInternal(ReorderableList reorderableList, string referenceClassName)
+        {
+            Type referenceType = Type.GetType(referenceClassName);
+            for (int index = 0; index < reorderableList.count; index++)
+            {
+                SerializedProperty property = reorderableList.serializedProperty.GetArrayElementAtIndex(index);
+                ScriptableObjectCollectionItem collectionItem =
+                    property.objectReferenceValue as ScriptableObjectCollectionItem;
+
+                if (collectionItem == null || collectionItem.IsReference())
+                    continue;
+                string collectionPath = AssetDatabase.GetAssetPath(collectionItem.Collection);
+                DirectoryInfo baseDirectory = Directory.GetParent(collectionPath);
+                if (baseDirectory == null)
+                {
+                    Debug.LogWarning($"The collection path \"{collectionPath}\" for the item \"{collectionItem.name}\" is invalid! " +
+                                     $"Skipping conversion for this item");
+                    continue;
+                }
+
+                var item = (ScriptableObjectCollectionItem)ScriptableObject.CreateInstance(referenceType);
+                item.name = $"{collectionItem.name}Reference";
+                item.SetCollection(collectionItem.Collection);
+                if (!item.TryGetReference(out var referenceItem))
+                    throw new Exception("Something went wrong!");
+                referenceItem.targetGuid = collectionItem.GUID;
+                
+                string referencesDirectory = Path.Combine(baseDirectory.ToString(), "References");
+                Directory.CreateDirectory(referencesDirectory);
+                AssetDatabase.CreateAsset(item, Path.Combine(referencesDirectory, $"{item.name}.asset"));
+                
+                CreateAddressablesGroups(collectionItem);
+                property.objectReferenceValue = item;
+                property.serializedObject.ApplyModifiedProperties();
+            }
+        }
+        
+        private static void CreateAddressablesGroups(ScriptableObjectCollectionItem collectionItem)
+        {
+            AddressableAssetSettings settings = AddressableAssetSettingsDefaultObject.Settings;
+            AddressableAssetEntry entry = settings.FindAssetEntry(collectionItem.GUID);
+            if (entry == null)
+            {
+                string collectionName = collectionItem.Collection.name;
+                AddressableAssetGroup assetGroup = settings.FindGroup(collectionName) ??
+                                                   settings.CreateGroup(collectionName, false, false, false, null,
+                                                       typeof(ContentUpdateGroupSchema), typeof(BundledAssetGroupSchema));
+                assetGroup.GetSchema<ContentUpdateGroupSchema>().StaticContent = true;
+                settings.CreateOrMoveEntry(collectionItem.GUID, assetGroup);
+                EditorUtility.SetDirty(assetGroup);
+            }
+        }
+        
+        private static void ShowProgressBar(string state, float progress)
+        {
+            EditorUtility.DisplayProgressBar("Converting to references...", state, progress);
+            Debug.Log(state);
+        }
+    }
+}
+#endif

--- a/Scripts/Editor/Core/ReferenceConverter.cs.meta
+++ b/Scripts/Editor/Core/ReferenceConverter.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 0ca0141009a14715bf11db42f5aa418f
+timeCreated: 1651594711

--- a/Scripts/Editor/Core/ScriptableObjectReferenceItemEditor.cs
+++ b/Scripts/Editor/Core/ScriptableObjectReferenceItemEditor.cs
@@ -13,7 +13,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
         
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
         {
-            itemGuidSerializedProperty = property.FindPropertyRelative(nameof(ScriptableObjectReferenceItem.targetGuid));
+            itemGuidSerializedProperty = property.FindPropertyRelative(nameof(ScriptableObjectReferenceItem.TargetGuid));
             if (item == null && !String.IsNullOrEmpty(itemGuidSerializedProperty.stringValue))
             {
                 item = AssetDatabase.LoadAssetAtPath<ScriptableObjectCollectionItem>(

--- a/Scripts/Editor/Core/ScriptableObjectReferenceItemEditor.cs
+++ b/Scripts/Editor/Core/ScriptableObjectReferenceItemEditor.cs
@@ -1,0 +1,78 @@
+using System;
+using UnityEditor;
+using UnityEngine;
+
+namespace BrunoMikoski.ScriptableObjectCollections
+{
+    [CustomPropertyDrawer(typeof(ScriptableObjectReferenceItem))]
+    public sealed class ScriptableObjectReferenceItemEditor : PropertyDrawer
+    {
+        private SerializedProperty itemGuidSerializedProperty;
+        bool showTargetItem = true;
+        private ScriptableObjectCollectionItem item;
+        
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            itemGuidSerializedProperty = property.FindPropertyRelative(nameof(ScriptableObjectReferenceItem.targetGuid));
+            if (item == null && !String.IsNullOrEmpty(itemGuidSerializedProperty.stringValue))
+            {
+                item = AssetDatabase.LoadAssetAtPath<ScriptableObjectCollectionItem>(
+                    AssetDatabase.GUIDToAssetPath(itemGuidSerializedProperty.stringValue));
+            }
+            property.serializedObject.Update();
+            
+            EditorGUI.BeginProperty(position, label, property);
+            Rect rect = new Rect(position.x, position.y, position.width, EditorGUIUtility.singleLineHeight);
+            showTargetItem = EditorGUI.Foldout(rect, showTargetItem, "Target Item");
+            if (showTargetItem)
+            {             
+                EditorGUI.indentLevel++;
+                ShowTargetItem(position);
+                EditorGUI.indentLevel--;
+            }
+            EditorGUI.EndProperty();
+            EditorUtility.SetDirty(property.serializedObject.targetObject);
+        }
+        
+        public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+        {
+            if (showTargetItem)
+            {
+                return EditorGUIUtility.singleLineHeight * 2 + EditorGUIUtility.standardVerticalSpacing;
+            }
+            return EditorGUIUtility.singleLineHeight;
+        }
+        
+        private void ShowTargetItem(Rect position)
+        {
+            Rect rect = new Rect(position);
+            rect.y += EditorGUIUtility.singleLineHeight;
+            rect.height = EditorGUIUtility.singleLineHeight;
+            Type itemType = typeof(ScriptableObjectCollectionItem);
+            if (item != null)
+                itemType = item.GetType();
+            UnityEngine.Object objectSetByUser = EditorGUI.ObjectField(rect, item, itemType, false);
+            if (objectSetByUser is ScriptableObjectCollectionItem collectionItem && collectionItem.IsReference())
+            {
+                Debug.LogError($"Cannot reference another reference object <{collectionItem.name}>!");
+            }
+            else if (objectSetByUser != item)
+            {
+                if (objectSetByUser == null)
+                {
+                    item = null;
+                    itemGuidSerializedProperty.stringValue = string.Empty;
+                    itemGuidSerializedProperty.serializedObject.ApplyModifiedProperties();
+                }
+                else if (AssetDatabase.TryGetGUIDAndLocalFileIdentifier(objectSetByUser, out string newGuid,
+                             out long _))
+                {
+                    item = AssetDatabase.LoadAssetAtPath<ScriptableObjectCollectionItem>(
+                        AssetDatabase.GUIDToAssetPath(newGuid));
+                    itemGuidSerializedProperty.stringValue = newGuid;
+                    itemGuidSerializedProperty.serializedObject.ApplyModifiedProperties();
+                }
+            }
+        }
+    }
+}

--- a/Scripts/Editor/Core/ScriptableObjectReferenceItemEditor.cs.meta
+++ b/Scripts/Editor/Core/ScriptableObjectReferenceItemEditor.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: a438e3f394564b39a17526d50c009889
+timeCreated: 1643734169

--- a/Scripts/Editor/Utils/CodeGenerationUtility.cs
+++ b/Scripts/Editor/Utils/CodeGenerationUtility.cs
@@ -220,10 +220,14 @@ namespace BrunoMikoski.ScriptableObjectCollections
                 {
                     int baseClassPostFixLength = ReferenceConverter.BaseClassNamePostFix.Length;
                     if (className.Length > baseClassPostFixLength)
+                    {
                         className = className.Remove(className.Length - baseClassPostFixLength, baseClassPostFixLength);
+                    }
                 }
                 if (!writeAsPartial)
+                {
                     className = fileName;
+                }
                 else if (className.Equals(nameof(ScriptableObjectCollectionItem)))
                 {
                     Debug.LogWarning($"Cannot create static class using the collection type name ({nameof(ScriptableObjectCollectionItem)})"+

--- a/Scripts/Editor/Utils/CodeGenerationUtility.cs
+++ b/Scripts/Editor/Utils/CodeGenerationUtility.cs
@@ -357,7 +357,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
                 AppendLine(writer, indentation);
                 if (collectionItem.TryGetReference(out ScriptableObjectReferenceItem reference))
                 {
-                    if (reference.targetGuid != null)
+                    if (reference.TargetGuid != null)
                     {
                         GenerateLoadUtilForReferences(writer, ref indentation, reference, collectionItem.name);
                     }
@@ -388,7 +388,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
         {
             string staticGetter = name.Sanitize().FirstToUpper();
             ScriptableObjectCollectionItem item = AssetDatabase.LoadAssetAtPath<ScriptableObjectCollectionItem>(
-                AssetDatabase.GUIDToAssetPath(referenceItem.targetGuid));
+                AssetDatabase.GUIDToAssetPath(referenceItem.TargetGuid));
             string itemName = item.name.Sanitize().FirstToUpper();
             
             AppendLine(writer, indentation, $"[Obsolete(\"Items are no longer automatically loaded. Use Load{itemName} instead.\", true)]");

--- a/Scripts/Editor/Utils/CodeGenerationUtility.cs
+++ b/Scripts/Editor/Utils/CodeGenerationUtility.cs
@@ -425,7 +425,8 @@ namespace BrunoMikoski.ScriptableObjectCollections
                 "return true;",
                 "}",
                 $"public {itemClassName} Load() => referenceItem.Load<{itemClassName}>();",
-                $"public Task<{itemClassName}> LoadAsync() => referenceItem.LoadAsync<{itemClassName}>();"
+                $"public Task<{itemClassName}> LoadAsync() => referenceItem.LoadAsync<{itemClassName}>();",
+                "public void Unload() => referenceItem.Unload();"
             };
         }
     }

--- a/Scripts/Editor/Utils/CodeGenerationUtility.cs
+++ b/Scripts/Editor/Utils/CodeGenerationUtility.cs
@@ -216,6 +216,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
                 directives.AddRange(GetCollectionDirectives(collection));
                 string className = collection.GetItemType().Name;
 
+#if SOC_ADDRESSABLES
                 if (className.Contains(ReferenceConverter.BaseClassNamePostFix) && collection.Items.Count(item => item.IsReference()) > 0)
                 {
                     int baseClassPostFixLength = ReferenceConverter.BaseClassNamePostFix.Length;
@@ -224,6 +225,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
                         className = className.Remove(className.Length - baseClassPostFixLength, baseClassPostFixLength);
                     }
                 }
+#endif
                 if (!writeAsPartial)
                 {
                     className = fileName;

--- a/Scripts/Editor/Utils/CodeGenerationUtility.cs
+++ b/Scripts/Editor/Utils/CodeGenerationUtility.cs
@@ -356,7 +356,20 @@ namespace BrunoMikoski.ScriptableObjectCollections
                 AppendLine(writer, indentation, "}");
                 AppendLine(writer, indentation);
                 if (collectionItem.TryGetReference(out ScriptableObjectReferenceItem reference))
-                    GenerateLoadUtilForReferences(writer, ref indentation, reference, collectionItem.name);
+                {
+                    if (reference.targetGuid != null)
+                    {
+                        GenerateLoadUtilForReferences(writer, ref indentation, reference, collectionItem.name);
+                    }
+                    else
+                    {
+                        string warningMessage =
+                            $"Item \"{collectionItem.name}\" does not contain a valid reference! " +
+                            $"Assign a valid reference and regenerate the static class!";
+                        Debug.LogWarning(warningMessage);
+                        AppendLine(writer, indentation, $"// {warningMessage}");
+                    }
+                }
             }
             
             

--- a/Scripts/Editor/Wizzard/CreateCollectionWizard.cs
+++ b/Scripts/Editor/Wizzard/CreateCollectionWizard.cs
@@ -630,7 +630,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
                 folder,
                 Namespace, 
                 string.Empty,
-                $"public partial class {collectionItemName} : ScriptableObjectCollectionItem", 
+                $"public partial class {collectionItemName} : {nameof(ScriptableObjectCollectionItem)}", null, 
                     typeof(ScriptableObjectCollectionItem).Namespace);
         }
         
@@ -642,7 +642,9 @@ namespace BrunoMikoski.ScriptableObjectCollections
                 folder,
                 Namespace,
                 $"[CreateAssetMenu(menuName = \"ScriptableObject Collection/Collections/Create {CollectionName}\", fileName = \"{CollectionName}\", order = 0)]",
-                $"public class {CollectionName} : ScriptableObjectCollection<{collectionItemName}>", typeof(ScriptableObjectCollection).Namespace, "UnityEngine");
+                $"public class {CollectionName} : ScriptableObjectCollection<{collectionItemName}>",
+                null,
+                typeof(ScriptableObjectCollection).Namespace, "UnityEngine", "System.Collections.Generic");
 
             if (string.IsNullOrEmpty(Namespace))
                 LastCollectionFullName.Value = $"{CollectionName}";

--- a/Scripts/Editor/Wizzard/CreateNewCollectionItemFromBaseWizard.cs
+++ b/Scripts/Editor/Wizzard/CreateNewCollectionItemFromBaseWizard.cs
@@ -112,7 +112,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
                             
                             string parentFolder = AssetDatabase.GetAssetPath(targetFolder);
                             CodeGenerationUtility.CreateNewEmptyScript(newClassName,
-                                parentFolder, targetNamespace, string.Empty,$"public class {newClassName} : {targetType}",
+                                parentFolder, targetNamespace, string.Empty,$"public class {newClassName} : {targetType}", null,
                                 targetNamespace);
                             
                             AssetDatabase.SaveAssets();

--- a/Scripts/Runtime/BrunoMikoski.ScriptableObjectCollection.asmdef
+++ b/Scripts/Runtime/BrunoMikoski.ScriptableObjectCollection.asmdef
@@ -1,6 +1,10 @@
 {
     "name": "BrunoMikoski.ScriptableObjectCollection",
-    "references": [],
+    "rootNamespace": "",
+    "references": [
+        "Unity.Addressables",
+        "Unity.ResourceManager"
+    ],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
@@ -8,6 +12,12 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.addressables",
+            "expression": "1.0.0",
+            "define": "SOC_ADDRESSABLES"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/Scripts/Runtime/Core/CollectionsRegistry.cs
+++ b/Scripts/Runtime/Core/CollectionsRegistry.cs
@@ -75,7 +75,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
             for (int i = 0; i < collections.Count; i++)
             {
                 ScriptableObjectCollection scriptableObjectCollection = collections[i];
-                if (!scriptableObjectCollection.GetItemType().IsAssignableFrom(itemType))
+                if (!itemType.IsAssignableFrom(scriptableObjectCollection.GetItemType()))
                     continue;
 
                 results.AddRange(scriptableObjectCollection.Items);

--- a/Scripts/Runtime/Core/ScriptableObjectCollection.cs
+++ b/Scripts/Runtime/Core/ScriptableObjectCollection.cs
@@ -229,6 +229,12 @@ namespace BrunoMikoski.ScriptableObjectCollections
             return items.Contains(item);
         }
 
+        public bool ContainsReferenceTo(ScriptableObjectCollectionItem item)
+        {
+            return items.Exists(collectionItem =>
+                collectionItem.TryGetReference(out ScriptableObjectReferenceItem reference) && reference.targetGuid == item.GUID);
+        }
+
         public int IndexOf(object value)
         {
             return IndexOf((ScriptableObjectCollectionItem) value);
@@ -346,6 +352,8 @@ namespace BrunoMikoski.ScriptableObjectCollections
                 if (item.Collection.Contains(item))
                     continue;
                 
+                if (item.Collection.ContainsReferenceTo(item))
+                    continue;
                 Debug.Log($"Adding {item.name} to the Collection {this.name} its inside of the folder {folder}");
                 Add(item);
             }

--- a/Scripts/Runtime/Core/ScriptableObjectCollection.cs
+++ b/Scripts/Runtime/Core/ScriptableObjectCollection.cs
@@ -232,7 +232,8 @@ namespace BrunoMikoski.ScriptableObjectCollections
         public bool ContainsReferenceTo(ScriptableObjectCollectionItem item)
         {
             return items.Exists(collectionItem =>
-                collectionItem.TryGetReference(out ScriptableObjectReferenceItem reference) && reference.TargetGuid == item.GUID);
+                collectionItem.TryGetReference(out ScriptableObjectReferenceItem reference) && 
+                String.Equals(reference.TargetGuid, item.GUID, StringComparison.OrdinalIgnoreCase));
         }
 
         public int IndexOf(object value)
@@ -354,6 +355,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
                 
                 if (item.Collection.ContainsReferenceTo(item))
                     continue;
+                
                 Debug.Log($"Adding {item.name} to the Collection {this.name} its inside of the folder {folder}");
                 Add(item);
             }

--- a/Scripts/Runtime/Core/ScriptableObjectCollection.cs
+++ b/Scripts/Runtime/Core/ScriptableObjectCollection.cs
@@ -232,7 +232,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
         public bool ContainsReferenceTo(ScriptableObjectCollectionItem item)
         {
             return items.Exists(collectionItem =>
-                collectionItem.TryGetReference(out ScriptableObjectReferenceItem reference) && reference.targetGuid == item.GUID);
+                collectionItem.TryGetReference(out ScriptableObjectReferenceItem reference) && reference.TargetGuid == item.GUID);
         }
 
         public int IndexOf(object value)

--- a/Scripts/Runtime/Core/ScriptableObjectCollection.cs
+++ b/Scripts/Runtime/Core/ScriptableObjectCollection.cs
@@ -146,7 +146,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
             
             ScriptableObjectCollectionItem item = (ScriptableObjectCollectionItem)CreateInstance(collectionType);
             string assetPath = Path.GetDirectoryName(AssetDatabase.GetAssetPath(this));
-            string parentFolderPath = Path.Combine(assetPath, "Items");
+            string parentFolderPath = Path.Combine(assetPath, item.IsReference() ? "References" : "Items");
             AssetDatabaseUtils.CreatePathIfDontExist(parentFolderPath);
 
             string itemName = assetName;

--- a/Scripts/Runtime/Core/ScriptableObjectCollectionItem.cs
+++ b/Scripts/Runtime/Core/ScriptableObjectCollectionItem.cs
@@ -46,6 +46,17 @@ namespace BrunoMikoski.ScriptableObjectCollections
             }
         }
 
+        public bool IsReference()
+        {
+            return TryGetReference(out _);
+        }
+        
+        public virtual bool TryGetReference(out ScriptableObjectReferenceItem reference)
+        {
+            reference = null;
+            return false;
+        }
+
         public void SetCollection(ScriptableObjectCollection collection)
         {
             cachedScriptableObjectCollection = collection;

--- a/Scripts/Runtime/Core/ScriptableObjectReferenceItem.cs
+++ b/Scripts/Runtime/Core/ScriptableObjectReferenceItem.cs
@@ -1,0 +1,78 @@
+using UnityEngine;
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+#if SOC_ADDRESSABLES
+using System;
+using System.Threading.Tasks;
+using UnityEngine.AddressableAssets;
+using UnityEngine.ResourceManagement.AsyncOperations;
+#endif
+
+namespace BrunoMikoski.ScriptableObjectCollections
+{
+    [Serializable]
+    public class ScriptableObjectReferenceItem
+    {
+#if SOC_ADDRESSABLES
+        [System.NonSerialized]
+        public AsyncOperationHandle handle;
+#endif
+        [SerializeField]
+        public string targetGuid;
+
+        public TObject Load<TObject>()
+#if UNITY_EDITOR && !SOC_ADDRESSABLES
+        where TObject : UnityEngine.Object
+#endif
+        {
+            TObject asset = default;
+            if (!string.IsNullOrEmpty(targetGuid))
+            {
+#if SOC_ADDRESSABLES
+                try
+                {
+                    var typeHandle = Addressables.LoadAssetAsync<TObject>(targetGuid);
+                    asset = typeHandle.WaitForCompletion();
+                    handle = typeHandle;
+                }
+                catch (Exception exception)
+                {
+                    Debug.LogError(exception);
+                    throw;
+                }
+
+#elif UNITY_EDITOR
+                asset = AssetDatabase.LoadAssetAtPath<TObject>(AssetDatabase.GUIDToAssetPath(targetGuid));
+#else
+                throw new Exception("Addressables wasn't detected! Please install it in order to use ScriptableObjectReferenceItems.")
+#endif
+            }
+            return asset;
+        }
+
+#if SOC_ADDRESSABLES
+        public async Task<TObject> LoadAsync<TObject>()
+        {
+            TObject asset = default;
+            if (!string.IsNullOrEmpty(targetGuid))
+            {
+                var typeHandle = 
+                    Addressables.LoadAssetAsync<TObject>(targetGuid);
+                await typeHandle.Task;
+                asset = typeHandle.Result;
+                handle = typeHandle;
+            }
+            return asset;
+        }
+#endif
+
+        public void Unload()
+        {
+#if SOC_ADDRESSABLES
+            if (handle.IsValid())
+                Addressables.Release(handle);
+#endif
+        }
+    }
+}

--- a/Scripts/Runtime/Core/ScriptableObjectReferenceItem.cs
+++ b/Scripts/Runtime/Core/ScriptableObjectReferenceItem.cs
@@ -18,8 +18,13 @@ namespace BrunoMikoski.ScriptableObjectCollections
         [System.NonSerialized]
         public AsyncOperationHandle handle;
 #endif
-        [SerializeField]
-        public string targetGuid;
+        [SerializeField] private string targetGuid;
+
+        public string TargetGuid
+        {
+            get => targetGuid;
+            set => targetGuid = value;
+        }
 
         public TObject Load<TObject>()
 #if UNITY_EDITOR && !SOC_ADDRESSABLES
@@ -27,12 +32,12 @@ namespace BrunoMikoski.ScriptableObjectCollections
 #endif
         {
             TObject asset = default;
-            if (!string.IsNullOrEmpty(targetGuid))
+            if (!string.IsNullOrEmpty(TargetGuid))
             {
 #if SOC_ADDRESSABLES
                 try
                 {
-                    var typeHandle = Addressables.LoadAssetAsync<TObject>(targetGuid);
+                    var typeHandle = Addressables.LoadAssetAsync<TObject>(TargetGuid);
                     asset = typeHandle.WaitForCompletion();
                     handle = typeHandle;
                 }
@@ -55,10 +60,10 @@ namespace BrunoMikoski.ScriptableObjectCollections
         public async Task<TObject> LoadAsync<TObject>()
         {
             TObject asset = default;
-            if (!string.IsNullOrEmpty(targetGuid))
+            if (!string.IsNullOrEmpty(TargetGuid))
             {
                 var typeHandle = 
-                    Addressables.LoadAssetAsync<TObject>(targetGuid);
+                    Addressables.LoadAssetAsync<TObject>(TargetGuid);
                 await typeHandle.Task;
                 asset = typeHandle.Result;
                 handle = typeHandle;

--- a/Scripts/Runtime/Core/ScriptableObjectReferenceItem.cs
+++ b/Scripts/Runtime/Core/ScriptableObjectReferenceItem.cs
@@ -1,9 +1,9 @@
 using UnityEngine;
+using System;
 #if UNITY_EDITOR
 using UnityEditor;
 #endif
 #if SOC_ADDRESSABLES
-using System;
 using System.Threading.Tasks;
 using UnityEngine.AddressableAssets;
 using UnityEngine.ResourceManagement.AsyncOperations;
@@ -70,14 +70,12 @@ namespace BrunoMikoski.ScriptableObjectCollections
             }
             return asset;
         }
-#endif
 
         public void Unload()
         {
-#if SOC_ADDRESSABLES
             if (handle.IsValid())
                 Addressables.Release(handle);
-#endif
         }
+#endif
     }
 }

--- a/Scripts/Runtime/Core/ScriptableObjectReferenceItem.cs
+++ b/Scripts/Runtime/Core/ScriptableObjectReferenceItem.cs
@@ -50,7 +50,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
 #elif UNITY_EDITOR
                 asset = AssetDatabase.LoadAssetAtPath<TObject>(AssetDatabase.GUIDToAssetPath(targetGuid));
 #else
-                throw new Exception("Addressables wasn't detected! Please install it in order to use ScriptableObjectReferenceItems.")
+                throw new InvalidOperationException("Addressables wasn't detected! Please install it in order to use ScriptableObjectReferenceItems.")
 #endif
             }
             return asset;

--- a/Scripts/Runtime/Core/ScriptableObjectReferenceItem.cs.meta
+++ b/Scripts/Runtime/Core/ScriptableObjectReferenceItem.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: a774df099b844adeb4973dc5a0c0dc10
+timeCreated: 1643733495


### PR DESCRIPTION
Hey as discussed, here are the proposed changes to add references to collections.
Essentially it is now possible to convert all items in a collection to references. These references are stored inside Addressables.
![Screenshot 2022-05-09 at 17 51 16](https://user-images.githubusercontent.com/11168507/167458858-84a2555a-d428-4635-8bbf-cfcba01dece0.png)
It is then possible to add references or items to the collection by using the add (plus) button:
![Screenshot 2022-05-09 at 18 45 44](https://user-images.githubusercontent.com/11168507/167467307-f27d751b-e5c6-4e91-a510-11417775a9a2.png)
For the sake of simplicity, I'll provide examples using the names of the `Weapons` collection shown in the screenshots.
The conversion process entails several steps:
* Marks every ScriptableObjectCollectionItem of the collection as Addressable. An Addressable group is created (or reused) for this scenario.
* Creates new item base class type (`WeaponBase`). 
* Creates a new reference class type (`WeaponReference`) as inherits the new item base class (`WeaponBase`).
  * This reference class contains a reference object that only contains a GUID to the target item.
* Swaps the the base class (`ScriptableObjectCollectionItem`) of the item class ( `WeaponBase`) for the new base class ( `WeaponBase`). This step does not fully regenerate the class, it just finds and replaces the base class type.
* Updates the collection class (`WeaponCollection`) swapping the type argument of the generic collection class (previously `Weapon`) for the new base class (`WeaponBase`).
  * This also does not fully regenerate the class. (if the developers wrote code in the collection class it won't be overridden)
* Creates scriptable object items of the reference class. These SOs are created in a new directory named "References" next to the Item collection directory.
* Regenerates the static class code.
Once the process is complete, developers can use the Load util method provided for each item on the static class (example `LoadAK47()`) to load the item.

Some advantages of the reference system:
> [+]Unified solution that can be applied to any collection the same way
> [+]The only thing getting into the resources are GUIDs
> [+]Automatically sets the required assets as addressables in a isolated group
> [+]More control, can partially load/unload collections

Additionally, this PR includes fixes to the core system that I've stumbled upon testing the references feature.

Keep in mind this is the first iteration and more improvements are possible in the horizon. (For example, better editor UI to manipulate references in the collection)

Also as you asked, I've updated the wiki. But this update is only in my [fork](https://github.com/IkeikeP/ScriptableObjectCollection/wiki/FAQ) (Not possible to create a PR to the wiki repo nor I have permissions to push commits to it)