### PR TITLE
Fixed a compile warning to do with object fields.

### DIFF
--- a/Scripts/Editor/Core/CollectionCustomEditor.cs
+++ b/Scripts/Editor/Core/CollectionCustomEditor.cs
@@ -203,7 +203,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
                     {
                         bool guiEnabled = GUI.enabled;
                         GUI.enabled = false;
-                        EditorGUI.ObjectField(rect, refItem, typeof(ScriptableObjectReferenceItem));
+                        EditorGUI.ObjectField(rect, refItem, typeof(ScriptableObjectReferenceItem), false);
                         GUI.enabled = guiEnabled;
                         rect.y += EditorGUIUtility.singleLineHeight + EditorGUIUtility.standardVerticalSpacing;
                     }


### PR DESCRIPTION
- Fixed a compile warning caused by an obsolete overload of the `EditorGUI.ObjectField` method