### PR TITLE
Feature/create collection from seed

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -5,7 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Added
+- Standalone scriptable object for advanced settings (ScriptableObjectCollectionAdvancedSettings).
+- Ability to assign advanced settings during the creation of a collection.
+### Changed
+- Isolated advanced settings on their own struct, and respective PropertyDrawer. 
 
 # [1.9.5]
 ### Changed

--- a/Scripts/Editor/Core/CollectionAdvancedSettingsPropertyDrawer.cs
+++ b/Scripts/Editor/Core/CollectionAdvancedSettingsPropertyDrawer.cs
@@ -1,0 +1,231 @@
+using System;
+using System.IO;
+using UnityEditor;
+using UnityEditor.Compilation;
+using UnityEngine;
+
+namespace BrunoMikoski.ScriptableObjectCollections 
+{
+    [CustomPropertyDrawer(typeof(CollectionAdvancedSettings), true)]
+    public sealed class CollectionAdvancedSettingsPropertyDrawer : PropertyDrawer 
+    {
+        private bool initialized = false;
+        private ScriptableObjectCollection collection;
+        private SerializedProperty targetProperty;
+        
+        private void Initialize(SerializedProperty property) 
+        {
+            this.collection = property.serializedObject.targetObject as ScriptableObjectCollection;
+            this.targetProperty = property;
+            
+            CheckGeneratedCodeLocation();
+            CheckGeneratedStaticFileName();
+
+            this.initialized = true;
+        }
+
+        private void CheckGeneratedStaticFileName()
+        {
+            SerializedProperty fileNameSerializedProperty = targetProperty.DeepFindPropertyRelative("GeneratedStaticClassFileName");
+            if (!string.IsNullOrEmpty(fileNameSerializedProperty.stringValue) || collection == null)
+                return;
+            
+            if (collection.name.Equals(collection.GetItemType().Name, StringComparison.Ordinal) 
+                && targetProperty.DeepFindPropertyRelative("GenerateAsPartialClass").boolValue)
+            {
+                fileNameSerializedProperty.stringValue = $"{collection.GetItemType().Name}Static";
+            }
+            else
+            {
+                fileNameSerializedProperty.stringValue = $"{collection.name}Static".Sanitize().FirstToUpper();
+            }
+            fileNameSerializedProperty.serializedObject.ApplyModifiedProperties();
+        }
+
+        private void CheckGeneratedCodeLocation()
+        {
+            SerializedProperty generatedCodePathSerializedProperty = targetProperty.DeepFindPropertyRelative("GeneratedFileLocationPath");
+            if (!string.IsNullOrEmpty(generatedCodePathSerializedProperty.stringValue))
+                return;
+
+            ScriptableObjectCollectionSettings settingsInstance = ScriptableObjectCollectionSettings.GetInstance();
+            if (!string.IsNullOrEmpty(settingsInstance.DefaultGeneratedScriptsPath))
+            {
+                generatedCodePathSerializedProperty.stringValue = settingsInstance.DefaultGeneratedScriptsPath;
+                generatedCodePathSerializedProperty.serializedObject.ApplyModifiedProperties();
+            }
+            else if (collection)
+            {
+                string collectionScriptPath =
+                    Path.GetDirectoryName(AssetDatabase.GetAssetPath(MonoScript.FromScriptableObject(collection)));
+                
+                generatedCodePathSerializedProperty.stringValue = collectionScriptPath;
+                generatedCodePathSerializedProperty.serializedObject.ApplyModifiedProperties();
+            }
+        }
+
+        private bool CheckIfCanBePartial() 
+        {
+            if (collection == null) 
+            {
+                // If there's no collection, assume it can be partial, so the user can still set a value when creating
+                // a collection via advanced settings.
+                return true;
+            }
+            
+            SerializedProperty generatedCodePathSerializedProperty = targetProperty.DeepFindPropertyRelative("GeneratedFileLocationPath");
+            SerializedProperty usePartialClassSerializedProperty = targetProperty.DeepFindPropertyRelative("GenerateAsPartialClass");
+            string baseClassPath = AssetDatabase.GetAssetPath(MonoScript.FromScriptableObject(collection));
+            string baseAssembly = CompilationPipeline.GetAssemblyNameFromScriptPath(baseClassPath);
+            string targetGeneratedCodePath = CompilationPipeline.GetAssemblyNameFromScriptPath(generatedCodePathSerializedProperty.stringValue);
+            
+            // NOTE: If you're not using assemblies for your code, it's expected that 'targetGeneratedCodePath' would
+            // be the same as 'baseAssembly', but it isn't. 'targetGeneratedCodePath' seems to be empty in that case.
+            bool canBePartial = baseAssembly.Equals(targetGeneratedCodePath, StringComparison.Ordinal) ||
+                                string.IsNullOrEmpty(targetGeneratedCodePath);
+            
+            if (usePartialClassSerializedProperty.boolValue && !canBePartial)
+            {
+                usePartialClassSerializedProperty.boolValue = false;
+                usePartialClassSerializedProperty.serializedObject.ApplyModifiedProperties();
+            }
+
+            return canBePartial;
+        }
+
+        private void DrawAutomaticallyLoaded() 
+        {
+            SerializedProperty automaticLoadedSerializedProperty = targetProperty.DeepFindPropertyRelative("AutomaticallyLoaded");
+            using (EditorGUI.ChangeCheckScope changeCheck = new EditorGUI.ChangeCheckScope())
+            {
+                bool isAutomaticallyLoaded = EditorGUILayout.Toggle("Automatically Loaded", automaticLoadedSerializedProperty.boolValue);
+                if (changeCheck.changed)
+                {
+                    automaticLoadedSerializedProperty.boolValue = isAutomaticallyLoaded;
+                    automaticLoadedSerializedProperty.serializedObject.ApplyModifiedProperties();
+                }
+            }
+        }
+
+        private void DrawGeneratedClassParentFolder() 
+        {
+            SerializedProperty generatedCodePathSerializedProperty = targetProperty.DeepFindPropertyRelative("GeneratedFileLocationPath");
+            using (EditorGUI.ChangeCheckScope changeCheck = new EditorGUI.ChangeCheckScope())
+            {
+                DefaultAsset pathObject = AssetDatabase.LoadAssetAtPath<DefaultAsset>(generatedCodePathSerializedProperty.stringValue);
+                if (pathObject == null && !string.IsNullOrEmpty(ScriptableObjectCollectionSettings.GetInstance().DefaultGeneratedScriptsPath))
+                {
+                    pathObject = AssetDatabase.LoadAssetAtPath<DefaultAsset>(ScriptableObjectCollectionSettings
+                        .GetInstance().DefaultGeneratedScriptsPath);
+                }
+                
+                pathObject = (DefaultAsset) EditorGUILayout.ObjectField(
+                    "Generated Scripts Parent Folder",
+                    pathObject,
+                    typeof(DefaultAsset),
+                    false
+                );
+                string assetPath = AssetDatabase.GetAssetPath(pathObject);
+
+                if (changeCheck.changed || !string.Equals(generatedCodePathSerializedProperty.stringValue, assetPath, StringComparison.Ordinal))
+                {
+                    generatedCodePathSerializedProperty.stringValue = assetPath;
+                    generatedCodePathSerializedProperty.serializedObject.ApplyModifiedProperties();
+
+                    if (string.IsNullOrEmpty(ScriptableObjectCollectionSettings.GetInstance().DefaultGeneratedScriptsPath))
+                        ScriptableObjectCollectionSettings.GetInstance().SetDefaultGeneratedScriptsPath(assetPath);
+                }
+            }
+        }
+        
+        private void DrawGeneratedFileName()
+        {
+            SerializedProperty fileNameSerializedProperty = targetProperty.DeepFindPropertyRelative("GeneratedStaticClassFileName");
+            using (EditorGUI.ChangeCheckScope changeCheck = new EditorGUI.ChangeCheckScope())
+            {
+                string newFileName = EditorGUILayout.DelayedTextField("Static File Name", fileNameSerializedProperty.stringValue);
+                if (changeCheck.changed)
+                {
+                    fileNameSerializedProperty.stringValue = newFileName;
+                    fileNameSerializedProperty.serializedObject.ApplyModifiedProperties();
+                }
+            }
+        }
+
+        private void DrawGeneratedFileNamespace()
+        {
+            SerializedProperty fileNamespaceSerializedProperty = targetProperty.DeepFindPropertyRelative("GenerateStaticFileNamespace");
+            if (string.IsNullOrEmpty(fileNamespaceSerializedProperty.stringValue))
+            {
+                if (collection != null)
+                {
+                    string targetNamespace = collection.GetItemType().Namespace;
+                    if (!string.IsNullOrEmpty(targetNamespace))
+                    {
+                        fileNamespaceSerializedProperty.stringValue = targetNamespace;
+                        fileNamespaceSerializedProperty.serializedObject.ApplyModifiedProperties();
+                    }
+                }
+            }
+            
+            using (EditorGUI.ChangeCheckScope changeCheck = new EditorGUI.ChangeCheckScope())
+            {
+                string newFileName = EditorGUILayout.DelayedTextField("Namespace", fileNamespaceSerializedProperty.stringValue);
+                if (changeCheck.changed)
+                {
+                    fileNamespaceSerializedProperty.stringValue = newFileName;
+                    fileNamespaceSerializedProperty.serializedObject.ApplyModifiedProperties();
+                }
+            }
+        }
+
+        private void DrawPartialClassToggle()
+        {
+            SerializedProperty usePartialClassSerializedProperty = targetProperty.DeepFindPropertyRelative("GenerateAsPartialClass");
+            bool canBePartial = CheckIfCanBePartial();
+            
+            EditorGUI.BeginDisabledGroup(!canBePartial);
+            using (EditorGUI.ChangeCheckScope changeCheck = new EditorGUI.ChangeCheckScope())
+            {
+                bool writeAsPartial = EditorGUILayout.Toggle("Write as Partial Class", usePartialClassSerializedProperty.boolValue);
+                if (changeCheck.changed)
+                {
+                    usePartialClassSerializedProperty.boolValue = writeAsPartial;
+                    usePartialClassSerializedProperty.serializedObject.ApplyModifiedProperties();
+                }
+            }
+
+            EditorGUI.EndDisabledGroup();
+        }
+        
+        private void DrawUseBaseClassToggle()
+        {
+            SerializedProperty useBaseClassProperty = targetProperty.DeepFindPropertyRelative("GenerateAsBaseClass");
+    
+            using (EditorGUI.ChangeCheckScope changeCheck = new EditorGUI.ChangeCheckScope())
+            {
+                bool useBaseClass = EditorGUILayout.Toggle("Use Base Class for items", useBaseClassProperty.boolValue);
+                if (changeCheck.changed)
+                {
+                    useBaseClassProperty.boolValue = useBaseClass;
+                    useBaseClassProperty.serializedObject.ApplyModifiedProperties();
+                }
+            }
+        }        
+        
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label) 
+        {
+            if (!this.initialized) 
+            {
+                this.Initialize(property);
+            }
+            
+            DrawAutomaticallyLoaded();
+            DrawGeneratedClassParentFolder();
+            DrawPartialClassToggle();
+            DrawUseBaseClassToggle();
+            DrawGeneratedFileName();
+            DrawGeneratedFileNamespace();
+        }
+    }
+}

--- a/Scripts/Editor/Core/CollectionAdvancedSettingsPropertyDrawer.cs.meta
+++ b/Scripts/Editor/Core/CollectionAdvancedSettingsPropertyDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 61c56a3842c8544f59188c5755a093fd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Editor/Core/ScriptableObjectCollectionAdvancedSettingsEditor.cs
+++ b/Scripts/Editor/Core/ScriptableObjectCollectionAdvancedSettingsEditor.cs
@@ -1,0 +1,12 @@
+using UnityEditor;
+
+namespace BrunoMikoski.ScriptableObjectCollections 
+{
+    [CustomEditor(typeof(ScriptableObjectCollectionAdvancedSettings), true)]
+    public sealed class ScriptableObjectCollectionAdvancedSettingsEditor : Editor 
+    {
+        // This editor exists solely to allow the usage of the auto layout system on the Advanced Settings
+        // property drawer (prevents ArgumentException: Getting control 1's position in a group with only 1
+        // controls when doing repaint).
+    }
+}

--- a/Scripts/Editor/Core/ScriptableObjectCollectionAdvancedSettingsEditor.cs.meta
+++ b/Scripts/Editor/Core/ScriptableObjectCollectionAdvancedSettingsEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 09022c7424c8643a7bbc81fbc726db41
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Editor/Extensions.meta
+++ b/Scripts/Editor/Extensions.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 198de865c6ecc4dbaacea232b59d00d9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Editor/Extensions/SerializedObjectExtension.cs
+++ b/Scripts/Editor/Extensions/SerializedObjectExtension.cs
@@ -1,0 +1,19 @@
+using UnityEditor;
+
+namespace BrunoMikoski.ScriptableObjectCollections 
+{
+    public static class SerializedObjectExtension 
+    {
+        public static SerializedProperty DeepFindProperty(this SerializedObject @object, string propertyPath) 
+        {
+            SerializedProperty property = @object.FindProperty(propertyPath);
+
+            if (property == null) 
+            {
+                property = @object.FindProperty($"<{propertyPath}>k__BackingField");
+            }
+
+            return property;
+        }
+    }
+}

--- a/Scripts/Editor/Extensions/SerializedObjectExtension.cs.meta
+++ b/Scripts/Editor/Extensions/SerializedObjectExtension.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 80addc9b3faf644298164ef28c547487
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Editor/Extensions/SerializedPropertyExtension.cs
+++ b/Scripts/Editor/Extensions/SerializedPropertyExtension.cs
@@ -1,0 +1,19 @@
+using UnityEditor;
+
+namespace BrunoMikoski.ScriptableObjectCollections 
+{
+    public static class SerializedPropertyExtension
+    {
+        public static SerializedProperty DeepFindPropertyRelative(this SerializedProperty property, string relativePropertyPath) 
+        {
+            SerializedProperty relativeProperty = property.FindPropertyRelative(relativePropertyPath);
+
+            if (relativeProperty == null) 
+            {
+                relativeProperty = property.FindPropertyRelative($"<{relativePropertyPath}>k__BackingField");
+            }
+
+            return relativeProperty;
+        }
+    }
+}

--- a/Scripts/Editor/Extensions/SerializedPropertyExtension.cs.meta
+++ b/Scripts/Editor/Extensions/SerializedPropertyExtension.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b66553c934d844356a597e1f5682d8a3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Editor/Utils/CodeGenerationUtility.cs
+++ b/Scripts/Editor/Utils/CodeGenerationUtility.cs
@@ -192,14 +192,14 @@ namespace BrunoMikoski.ScriptableObjectCollections
             }
 
             SerializedObject collectionSerializedObject = new SerializedObject(collection);
-
-
-            string fileName = collectionSerializedObject.FindProperty("generatedStaticClassFileName").stringValue;
-            string nameSpace = collectionSerializedObject.FindProperty("generateStaticFileNamespace").stringValue;
+            SerializedProperty advancedSettings = collectionSerializedObject.DeepFindProperty("AdvancedSettings");
+        
+            string fileName = advancedSettings.DeepFindPropertyRelative("GeneratedStaticClassFileName").stringValue;
+            string nameSpace = advancedSettings.DeepFindPropertyRelative("GenerateStaticFileNamespace").stringValue;
            
-            string finalFolder = collectionSerializedObject.FindProperty("generatedFileLocationPath").stringValue;
-            bool writeAsPartial = collectionSerializedObject.FindProperty("generateAsPartialClass").boolValue;
-            bool useBaseClass = collectionSerializedObject.FindProperty("generateAsBaseClass").boolValue;
+            string finalFolder = advancedSettings.DeepFindPropertyRelative("GeneratedFileLocationPath").stringValue;
+            bool writeAsPartial = advancedSettings.DeepFindPropertyRelative("GenerateAsPartialClass").boolValue;
+            bool useBaseClass = advancedSettings.DeepFindPropertyRelative("GenerateAsBaseClass").boolValue;
 
 
             AssetDatabaseUtils.CreatePathIfDontExist(finalFolder);

--- a/Scripts/Editor/Wizzard/CreateCollectionWizard.cs
+++ b/Scripts/Editor/Wizzard/CreateCollectionWizard.cs
@@ -246,6 +246,8 @@ namespace BrunoMikoski.ScriptableObjectCollections
             }
         }
 
+        private ScriptableObjectCollectionAdvancedSettings settingsObject;
+
         private static readonly EditorPreferenceBool FoldoutSettings =
             new EditorPreferenceBool(FOLDOUT_SETTINGS_KEY, true);
         private static readonly EditorPreferenceBool FoldoutScriptableObject =
@@ -384,10 +386,9 @@ namespace BrunoMikoski.ScriptableObjectCollections
         private void DrawSections()
         {
             DrawSettingsSection();
-
             DrawScriptableObjectSection();
-
             DrawScriptsSection();
+            DrawAdvancedSettingsSection();
         }
 
         private void SetColorBasedOnFieldValidity(Fields field)
@@ -543,6 +544,26 @@ namespace BrunoMikoski.ScriptableObjectCollections
                     GUI.enabled = wasGuiEnabled;
                 }
 
+                EditorGUILayout.EndFoldoutHeaderGroup();
+                EditorGUI.indentLevel--;
+            }
+        }
+
+        private void DrawAdvancedSettingsSection()
+        {   
+            using (new EditorGUILayout.VerticalScope("Box"))
+            {
+                FoldoutScriptableObject.Value = EditorGUILayout.BeginFoldoutHeaderGroup(
+                    FoldoutScriptableObject.Value, "Advanced Settings");
+
+                EditorGUI.indentLevel++;
+                if (FoldoutScriptableObject.Value)
+                {
+                    settingsObject = (ScriptableObjectCollectionAdvancedSettings)EditorGUILayout.ObjectField(
+                        "Settings Object",
+                        settingsObject, typeof(ScriptableObjectCollectionAdvancedSettings),
+                        false);
+                }
                 EditorGUILayout.EndFoldoutHeaderGroup();
                 EditorGUI.indentLevel--;
             }
@@ -712,7 +733,21 @@ namespace BrunoMikoski.ScriptableObjectCollections
             ScriptableObjectCollection collectionAsset =
                 ScriptableObjectCollectionUtils.CreateScriptableObjectOfType(targetType, 
                     windowInstance.ScriptableObjectFolderPath, windowInstance.CollectionName) as ScriptableObjectCollection;
-            
+
+            if (collectionAsset) 
+            {
+                if (windowInstance.settingsObject) 
+                {
+                    collectionAsset.AdvancedSettings = windowInstance.settingsObject.Settings;
+                } 
+                else 
+                {
+                    CollectionAdvancedSettings defaultSettings = collectionAsset.AdvancedSettings;
+                    defaultSettings.SetDefaultValues();
+                    collectionAsset.AdvancedSettings = defaultSettings;
+                }
+            }
+
             Selection.objects = new Object[] {collectionAsset};
             EditorGUIUtility.PingObject(collectionAsset);
 

--- a/Scripts/Runtime/Core/CollectionAdvancedSettings.cs
+++ b/Scripts/Runtime/Core/CollectionAdvancedSettings.cs
@@ -1,0 +1,41 @@
+using System;
+using UnityEngine;
+
+namespace BrunoMikoski.ScriptableObjectCollections 
+{
+    [Serializable]
+    public struct CollectionAdvancedSettings 
+    {
+        [field: SerializeField]
+        public bool AutomaticallyLoaded { get; private set; }
+
+#if UNITY_EDITOR
+        [field: SerializeField] 
+        public bool GenerateAsPartialClass { get; private set; }
+
+        [field: SerializeField] 
+        public bool GenerateAsBaseClass { get; private set; }
+
+        [field: SerializeField] 
+        public string GeneratedFileLocationPath { get; private set; }
+
+        [field: SerializeField] 
+        public string GeneratedStaticClassFileName { get; private set; }
+
+        [field: SerializeField] 
+        public string GenerateStaticFileNamespace { get; private set; }
+#endif
+
+        public void SetDefaultValues() 
+        {
+            AutomaticallyLoaded = true;
+#if UNITY_EDITOR
+            GenerateAsPartialClass = true;
+            GenerateAsBaseClass = default;
+            GeneratedFileLocationPath = default;
+            GeneratedStaticClassFileName = default;
+            GenerateStaticFileNamespace = default;
+#endif
+        }
+    }
+}

--- a/Scripts/Runtime/Core/CollectionAdvancedSettings.cs.meta
+++ b/Scripts/Runtime/Core/CollectionAdvancedSettings.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4c64aa67efe3f44b497b97200eedcb06
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Core/ScriptableObjectCollection.cs
+++ b/Scripts/Runtime/Core/ScriptableObjectCollection.cs
@@ -30,22 +30,8 @@ namespace BrunoMikoski.ScriptableObjectCollections
         protected List<ScriptableObjectCollectionItem> items = new List<ScriptableObjectCollectionItem>();
         public List<ScriptableObjectCollectionItem> Items => items;
 
-#pragma warning disable 0414
-        [SerializeField]
-        private bool automaticallyLoaded = true;
-#if UNITY_EDITOR
-        [SerializeField]
-        private bool generateAsPartialClass = true;
-        [SerializeField]
-        private bool generateAsBaseClass = false;
-        [SerializeField]
-        private string generatedFileLocationPath;
-        [SerializeField]
-        private string generatedStaticClassFileName;
-        [SerializeField]
-        private string generateStaticFileNamespace;
-#pragma warning restore 0414
-#endif
+        [field: SerializeField]
+        public CollectionAdvancedSettings AdvancedSettings { get; set; }
 
         private void SyncGUID()
         {

--- a/Scripts/Runtime/Core/ScriptableObjectCollectionAdvancedSettings.cs
+++ b/Scripts/Runtime/Core/ScriptableObjectCollectionAdvancedSettings.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+namespace BrunoMikoski.ScriptableObjectCollections 
+{
+    [CreateAssetMenu(menuName = "ScriptableObject Collection/Settings/Create Advanced Settings", fileName = "Advanced Settings")]
+    public class ScriptableObjectCollectionAdvancedSettings : ScriptableObject {
+
+#pragma warning disable 0414
+        [field: SerializeField] 
+        public CollectionAdvancedSettings Settings { get; private set; }
+#pragma warning restore 0414
+    }
+}

--- a/Scripts/Runtime/Core/ScriptableObjectCollectionAdvancedSettings.cs.meta
+++ b/Scripts/Runtime/Core/ScriptableObjectCollectionAdvancedSettings.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 89f9b1a40d20745bb9f684ce5da91b85
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Hello!

I'm working on decreasing the effort of installing shared packages in different projects, and one of the steps is having packages generate their own scriptable object collections during the package installation. For this to be possible, I've done the following changes:

1. Isolated the advanced settings on a struct, so it can be reusable.
2. Created a ScriptableObject that contains the struct, for using as a shareable seed for the creation of a collection.
3. Added an Advanced Settings section on the wizard, so the user can set an existing seed.

The flow is already working manually. The next step will be to have this working automatically during the installation process, but in the meantime, do you think this is something useful to merge back into the original repo? I'm open to making any changes you deem necessary if it helps.

Cheers!