### PR TITLE
Made sure SOC Item references correctly show property overrides

### DIFF
--- a/Scripts/Editor/PropertyDrawers/SOCItemPropertyDrawer.cs
+++ b/Scripts/Editor/PropertyDrawers/SOCItemPropertyDrawer.cs
@@ -66,12 +66,14 @@ namespace BrunoMikoski.ScriptableObjectCollections
 
             item = property.objectReferenceValue as ScriptableObject;
 
+            EditorGUI.BeginProperty(position, label, property);
             DrawCollectionItemDrawer(ref position, item, label,
                 newItem =>
                 {
                     property.objectReferenceValue = newItem;
                     property.serializedObject.ApplyModifiedProperties();
                 });
+            EditorGUI.EndProperty();
         }
 
         internal void DrawCollectionItemDrawer(ref Rect position, ScriptableObject collectionItem, GUIContent label, 


### PR DESCRIPTION
- Overrides of an SOC Item reference are now correctly drawn as such

Before
![image](https://github.com/brunomikoski/ScriptableObjectCollection/assets/3997055/4b94b70f-fbf2-4986-9a26-80141b0455c1)

After
![image](https://github.com/brunomikoski/ScriptableObjectCollection/assets/3997055/996980ba-d272-45e4-a906-a43ac463b80a)
