### PR TITLE
Feature/new soc item editor options

### DIFF
--- a/Scripts/Editor/Core/CollectionItemDropdown.cs
+++ b/Scripts/Editor/Core/CollectionItemDropdown.cs
@@ -17,22 +17,22 @@ namespace BrunoMikoski.ScriptableObjectCollections
 
         private readonly Type itemType;
         private readonly SOCItemEditorOptionsAttribute options;
-        private readonly SerializedObject serializedObject;
+        private readonly SerializedProperty serializedProperty;
         private readonly MethodInfo validationMethod;
 
         public CollectionItemDropdown(AdvancedDropdownState state, Type targetItemType,
-            SOCItemEditorOptionsAttribute options, SerializedObject serializedObject) : base(state)
+            SOCItemEditorOptionsAttribute options, SerializedProperty serializedProperty) : base(state)
         {
             itemType = targetItemType;
             collections = CollectionsRegistry.Instance.GetCollectionsByItemType(itemType);
             minimumSize = new Vector2(200, 300);
             this.options = options;
-            this.serializedObject = serializedObject;
+            this.serializedProperty = serializedProperty;
 
 
             if (options != null)
             {
-                Object owner = serializedObject.targetObject;
+                Object owner = serializedProperty.serializedObject.targetObject;
                 if (!string.IsNullOrEmpty(options.ValidateMethod))
                     validationMethod = owner.GetType().GetMethod(options.ValidateMethod, new[] {itemType});
             }
@@ -49,13 +49,13 @@ namespace BrunoMikoski.ScriptableObjectCollections
             ScriptableObjectCollection collectionToConstrainTo = null;
             if (!string.IsNullOrEmpty(options.ConstrainToCollectionField))
             {
-                SerializedProperty collectionField = serializedObject.FindProperty(
+                SerializedProperty collectionField = serializedProperty.serializedObject.FindProperty(
                     options.ConstrainToCollectionField);
                 if (collectionField == null)
                 {
                     Debug.LogWarning($"Tried to constrain dropdown to collection specified in field " +
                                      $"'{options.ConstrainToCollectionField}' but no such field existed in " +
-                                     $"'{serializedObject.targetObject}'");
+                                     $"'{serializedProperty.serializedObject.targetObject}'");
                     return root;
                 }
 
@@ -98,7 +98,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
                     if (validationMethod != null)
                     {
                         bool result = (bool) validationMethod.Invoke(
-                            serializedObject.targetObject, new object[] {collectionItem});
+                            serializedProperty.serializedObject.targetObject, new object[] {collectionItem});
                         if (!result)
                             continue;
                     }

--- a/Scripts/Editor/Core/CollectionItemDropdown.cs
+++ b/Scripts/Editor/Core/CollectionItemDropdown.cs
@@ -37,6 +37,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
                 if (!string.IsNullOrEmpty(options.ValidateMethod))
                     validationMethod = owner.GetType().GetMethod(options.ValidateMethod, new[] {itemType});
                 
+                // If it's specified that a callback should be fired when an item is selected, cache that callback.
                 if (!string.IsNullOrEmpty(options.OnSelectCallbackMethod))
                 {
                     onSelectCallbackMethod = owner.GetType().GetMethod(options.OnSelectCallbackMethod,

--- a/Scripts/Editor/Core/CollectionItemDropdown.cs
+++ b/Scripts/Editor/Core/CollectionItemDropdown.cs
@@ -133,8 +133,21 @@ namespace BrunoMikoski.ScriptableObjectCollections
             if (onSelectCallbackMethod == null)
                 return;
 
-            object target = onSelectCallbackMethod.IsStatic ? null : serializedProperty.serializedObject.targetObject;
-            onSelectCallbackMethod.Invoke(target, new object[] {from, to});
+            object[] arguments = { from, to };
+            
+            // The method may be static, in which case there is no target.
+            if (onSelectCallbackMethod.IsStatic)
+            {
+                onSelectCallbackMethod.Invoke(null, arguments);
+                return;
+            }
+
+            // Otherwise, fire the callback on every target.
+            for (int i = 0; i < serializedProperty.serializedObject.targetObjects.Length; i++)
+            {
+                object target = serializedProperty.serializedObject.targetObjects[i];
+                onSelectCallbackMethod.Invoke(target, arguments);
+            }
         }
 
         protected override void ItemSelected(AdvancedDropdownItem item)

--- a/Scripts/Editor/Core/CollectionItemDropdown.cs
+++ b/Scripts/Editor/Core/CollectionItemDropdown.cs
@@ -42,6 +42,11 @@ namespace BrunoMikoski.ScriptableObjectCollections
                     onSelectCallbackMethod = owner.GetType().GetMethod(options.OnSelectCallbackMethod,
                         BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic,
                         null, new[] {itemType, itemType}, null);
+                    if (onSelectCallbackMethod == null)
+                    {
+                        Debug.LogWarning($"Component '{owner.name}' wants selection callback " +
+                                         $"'{options.OnSelectCallbackMethod}' which is not a valid method.");
+                    }
                 }
             }
         }

--- a/Scripts/Editor/PropertyDrawers/CollectionItemIndirectReferencePropertyDrawer.cs
+++ b/Scripts/Editor/PropertyDrawers/CollectionItemIndirectReferencePropertyDrawer.cs
@@ -41,7 +41,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
                 SetCollectionItemType();
             
             if (socItemPropertyDrawer == null) 
-                CreateCollectionItemPropertyDrawer(property.serializedObject);
+                CreateCollectionItemPropertyDrawer(property);
 
             drawingProperty = property;
             itemGUIDValueASerializedProperty = property.FindPropertyRelative(COLLECTION_ITEM_GUID_VALUE_A_PROPERTY_PATH);
@@ -133,10 +133,10 @@ namespace BrunoMikoski.ScriptableObjectCollections
             return true;
         }
 
-        private void CreateCollectionItemPropertyDrawer(SerializedObject serializedObject)
+        private void CreateCollectionItemPropertyDrawer(SerializedProperty serializedProperty)
         {
             socItemPropertyDrawer = new SOCItemPropertyDrawer();
-            socItemPropertyDrawer.Initialize(collectionItemType, serializedObject, GetOptionsAttribute());
+            socItemPropertyDrawer.Initialize(collectionItemType, serializedProperty, GetOptionsAttribute());
         }
 
         private void SetCollectionItemType()

--- a/Scripts/Editor/PropertyDrawers/CollectionItemIndirectReferencePropertyDrawer.cs
+++ b/Scripts/Editor/PropertyDrawers/CollectionItemIndirectReferencePropertyDrawer.cs
@@ -64,17 +64,16 @@ namespace BrunoMikoski.ScriptableObjectCollections
 
             if (socItemPropertyDrawer.OptionsAttribute.DrawType == DrawType.Dropdown)
             {
-                DrawItemDrawer(position, label, collectionItem);
+                DrawItemDrawer(position, property, label, collectionItem);
                 return;
             }
 
             EditorGUI.PropertyField(position, property, label, true);
         }
 
-        private void DrawItemDrawer(Rect position, GUIContent label, ScriptableObject collectionItem
-        )
+        private void DrawItemDrawer(Rect position, SerializedProperty property, GUIContent label, ScriptableObject collectionItem)
         {
-            socItemPropertyDrawer.DrawCollectionItemDrawer(ref position, collectionItem, label, item =>
+            socItemPropertyDrawer.DrawCollectionItemDrawer(ref position, property, collectionItem, label, item =>
             {
                 SetSerializedPropertyGUIDs(item);
                 drawingProperty.serializedObject.ApplyModifiedProperties();

--- a/Scripts/Editor/PropertyDrawers/CollectionItemIndirectReferencePropertyDrawer.cs
+++ b/Scripts/Editor/PropertyDrawers/CollectionItemIndirectReferencePropertyDrawer.cs
@@ -41,7 +41,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
                 SetCollectionItemType();
             
             if (socItemPropertyDrawer == null) 
-                CreateCollectionItemPropertyDrawer(property.serializedObject.targetObject);
+                CreateCollectionItemPropertyDrawer(property.serializedObject);
 
             drawingProperty = property;
             itemGUIDValueASerializedProperty = property.FindPropertyRelative(COLLECTION_ITEM_GUID_VALUE_A_PROPERTY_PATH);
@@ -133,11 +133,10 @@ namespace BrunoMikoski.ScriptableObjectCollections
             return true;
         }
 
-        private void CreateCollectionItemPropertyDrawer(Object serializedObjectTargetObject)
+        private void CreateCollectionItemPropertyDrawer(SerializedObject serializedObject)
         {
             socItemPropertyDrawer = new SOCItemPropertyDrawer();
-            socItemPropertyDrawer.Initialize(collectionItemType, serializedObjectTargetObject,
-                GetOptionsAttribute());
+            socItemPropertyDrawer.Initialize(collectionItemType, serializedObject, GetOptionsAttribute());
         }
 
         private void SetCollectionItemType()

--- a/Scripts/Editor/PropertyDrawers/SOCItemPropertyDrawer.cs
+++ b/Scripts/Editor/PropertyDrawers/SOCItemPropertyDrawer.cs
@@ -216,6 +216,8 @@ namespace BrunoMikoski.ScriptableObjectCollections
             bool canUseDropDown = true;
             bool isDropdownError = false;
 
+            // If the options are meant to be constrained to a specific collection, check if the collection specified
+            // is valid. If not, draw some useful messages so you're aware what's wrong and know how to fix it.
             if (!string.IsNullOrEmpty(OptionsAttribute.ConstrainToCollectionField))
             {
                 SerializedProperty collectionField = property.serializedObject.FindProperty(

--- a/Scripts/Editor/PropertyDrawers/SOCItemPropertyDrawer.cs
+++ b/Scripts/Editor/PropertyDrawers/SOCItemPropertyDrawer.cs
@@ -171,7 +171,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
                 itemType = arrayOrListType ?? TargetFieldInfo.FieldType;
             }
             
-            Initialize(itemType, property.serializedObject, GetOptionsAttribute());
+            Initialize(itemType, property, GetOptionsAttribute());
         }
 
         internal void Initialize(Type collectionItemType, SOCItemEditorOptionsAttribute optionsAttribute)
@@ -180,7 +180,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
         }
 
         internal void Initialize(
-            Type collectionItemType, SerializedObject serializedObject, SOCItemEditorOptionsAttribute optionsAttribute)
+            Type collectionItemType, SerializedProperty serializedProperty, SOCItemEditorOptionsAttribute optionsAttribute)
         {
             if (initialized)
                 return;
@@ -194,11 +194,11 @@ namespace BrunoMikoski.ScriptableObjectCollections
                 new AdvancedDropdownState(),
                 collectionItemType,
                 OptionsAttribute,
-                serializedObject
+                serializedProperty
             );
             
             currentItemType = collectionItemType;
-            currentObject = serializedObject.targetObject;
+            currentObject = serializedProperty.serializedObject.targetObject;
             initialized = true;
             
         }

--- a/Scripts/Editor/PropertyDrawers/SOCItemPropertyDrawer.cs
+++ b/Scripts/Editor/PropertyDrawers/SOCItemPropertyDrawer.cs
@@ -171,7 +171,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
                 itemType = arrayOrListType ?? TargetFieldInfo.FieldType;
             }
             
-            Initialize(itemType, property.serializedObject.targetObject, GetOptionsAttribute());
+            Initialize(itemType, property.serializedObject, GetOptionsAttribute());
         }
 
         internal void Initialize(Type collectionItemType, SOCItemEditorOptionsAttribute optionsAttribute)
@@ -179,7 +179,8 @@ namespace BrunoMikoski.ScriptableObjectCollections
             Initialize(collectionItemType, null, optionsAttribute ?? GetOptionsAttribute());
         }
 
-        internal void Initialize(Type collectionItemType, Object obj, SOCItemEditorOptionsAttribute optionsAttribute)
+        internal void Initialize(
+            Type collectionItemType, SerializedObject serializedObject, SOCItemEditorOptionsAttribute optionsAttribute)
         {
             if (initialized)
                 return;
@@ -193,10 +194,11 @@ namespace BrunoMikoski.ScriptableObjectCollections
                 new AdvancedDropdownState(),
                 collectionItemType,
                 OptionsAttribute,
-                obj
+                serializedObject
             );
+            
             currentItemType = collectionItemType;
-            currentObject = obj;
+            currentObject = serializedObject.targetObject;
             initialized = true;
             
         }

--- a/Scripts/Runtime/Attributes/SOCItemEditorOptionsAttribute.cs
+++ b/Scripts/Runtime/Attributes/SOCItemEditorOptionsAttribute.cs
@@ -29,6 +29,11 @@ namespace BrunoMikoski.ScriptableObjectCollections
         public bool ShouldDrawPreviewButton { get; set; } = true;
 
         public string ValidateMethod { get; set; }
+        
+        /// <summary>
+        /// If specified, only show collection items that belong to the collection assigned to the specified field.
+        /// </summary>
+        public string ConstrainToCollectionField { get; set; }
     }
 
     //Temporary 

--- a/Scripts/Runtime/Attributes/SOCItemEditorOptionsAttribute.cs
+++ b/Scripts/Runtime/Attributes/SOCItemEditorOptionsAttribute.cs
@@ -34,6 +34,12 @@ namespace BrunoMikoski.ScriptableObjectCollections
         /// If specified, only show collection items that belong to the collection assigned to the specified field.
         /// </summary>
         public string ConstrainToCollectionField { get; set; }
+        
+        /// <summary>
+        /// If specified, will perform this method whenever the value changes.
+        /// Parameters of the method should be: ItemType from, ItemType to
+        /// </summary>
+        public string OnSelectCallbackMethod { get; set; }
     }
 
     //Temporary 


### PR DESCRIPTION
- `[SOCItemEditorOptions]` now has the option to limit the displayed items to the collection selected in a given field using the `ConstrainToCollectionField` parameter.
- `[SOCItemEditorOptions]` now has the option to fire a callback when a value is selected using the `OnSelectCallbackMethod` parameter.