### PR TITLE
Feature/added smarter load unloaded collections

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed issue while renaming one asset could be canceled on arrow keys press
 - Fix removing wrong usages of ApplyModifiedProperties
 - Fixed issue with the CollectionItemPicker not updating the collection properly on editor mode
+- Fixed issue with check if a collection could be partial not working, and newly created collections were not being generated as partial
+- Updated the Reload of collections when entering Edit Mode to only load collections that have been removed.
 
 ## [2.3.3]
 ## Added

--- a/Scripts/Editor/Core/CodeGenerationUtility.cs
+++ b/Scripts/Editor/Core/CodeGenerationUtility.cs
@@ -311,12 +311,16 @@ namespace BrunoMikoski.ScriptableObjectCollections
         {
             string baseClassPath = AssetDatabase.GetAssetPath(MonoScript.FromScriptableObject(collection));
             string baseAssembly = CompilationPipeline.GetAssemblyNameFromScriptPath(baseClassPath);
-            if(string.IsNullOrEmpty(destinationFolder))
-                destinationFolder = CompilationPipeline.GetAssemblyNameFromScriptPath(SOCSettings.Instance.GetParentFolderPathForCollection(collection));
-            
+            if (string.IsNullOrEmpty(destinationFolder))
+            {
+                destinationFolder = SOCSettings.Instance.GetParentFolderPathForCollection(collection);
+            }
+
+            string destinationFolderAssembly = CompilationPipeline.GetAssemblyNameFromScriptPath(destinationFolder);
+
             // NOTE: If you're not using assemblies for your code, it's expected that 'targetGeneratedCodePath' would
             // be the same as 'baseAssembly', but it isn't. 'targetGeneratedCodePath' seems to be empty in that case.
-            bool canBePartial = baseAssembly.Equals(destinationFolder, StringComparison.Ordinal) ||
+            bool canBePartial = baseAssembly.Equals(destinationFolderAssembly, StringComparison.Ordinal) ||
                                 string.IsNullOrEmpty(destinationFolder);
             
             return canBePartial;

--- a/Scripts/Editor/Core/EditorBehaviour.cs
+++ b/Scripts/Editor/Core/EditorBehaviour.cs
@@ -18,8 +18,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
             }
             else if (playModeStateChange == PlayModeStateChange.EnteredEditMode)
             {
-                if (CollectionsRegistry.Instance.AutoSearchForCollections)
-                    CollectionsRegistry.Instance.ReloadCollections();
+                CollectionsRegistry.Instance.ReloadUnloadedCollectionsIfNeeded();
             }
         }
     }

--- a/Scripts/Editor/CustomEditors/CollectionCustomEditor.cs
+++ b/Scripts/Editor/CustomEditors/CollectionCustomEditor.cs
@@ -171,6 +171,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
             Toggle automaticLoadToggle = root.Q<Toggle>("automatic-loaded-toggle");
             automaticLoadToggle.RegisterValueChangedCallback(evt =>
             {
+                UpdateAutomaticallyLoaded();
                 UpdateHelpBox();
             });
             
@@ -260,6 +261,11 @@ namespace BrunoMikoski.ScriptableObjectCollections
             root.schedule.Execute(OnVisualTreeCreated).ExecuteLater(100);
 
             return root;
+        }
+
+        private void UpdateAutomaticallyLoaded()
+        {
+            CollectionsRegistry.Instance.UpdateAutoSearchForCollections();
         }
 
         private VisualElement MakeCollectionItemListItem()


### PR DESCRIPTION
- Fixed issue with check if a collection could be partial not working, and newly created collections were not being generated as partial
- Updated the Reload of collections when entering Edit Mode to only load collections that have been removed.