### PR TITLE
Ensured that the namespace for generated code is the same as the script by default

### DIFF
--- a/Scripts/Editor/EditorWindows/CreateCollectionWizard.cs
+++ b/Scripts/Editor/EditorWindows/CreateCollectionWizard.cs
@@ -29,6 +29,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
         private const string WAITING_SCRIPTS_TO_RECOMPILE_TO_CONTINUE_KEY = "WaitingScriptsToRecompileToContinueKey";
         private const string LAST_COLLECTION_SCRIPTABLE_OBJECT_PATH_KEY = "CollectionScriptableObjectPathKey";
         private const string LAST_COLLECTION_FULL_NAME_KEY = "CollectionFullNameKey";
+        private const string LAST_COLLECTION_NAMESPACE_KEY = "CollectionNamespaceKey";
         private const string LAST_GENERATED_COLLECTION_SCRIPT_PATH_KEY = "CollectionScriptPathKey";
         private const string LAST_TARGET_SCRIPTS_FOLDER_KEY = "LastTargetScriptsFolder";
         private const string GENERATE_INDIRECT_ACCESS_KEY = "GenerateIndirectAccess";
@@ -265,6 +266,9 @@ namespace BrunoMikoski.ScriptableObjectCollections
 
         private static readonly EditorPreferenceString LastCollectionFullName =
             new EditorPreferenceString(LAST_COLLECTION_FULL_NAME_KEY, null, true);
+        
+        private static readonly EditorPreferenceString LastCollectionNamespace =
+            new EditorPreferenceString(LAST_COLLECTION_NAMESPACE_KEY, null, true);
 
         private static readonly EditorPreferenceString LastScriptsTargetFolder =
             new EditorPreferenceString(LAST_TARGET_SCRIPTS_FOLDER_KEY, null, true);
@@ -593,6 +597,8 @@ namespace BrunoMikoski.ScriptableObjectCollections
 
         private void CreateNewCollection()
         {
+            LastCollectionNamespace.Value = Namespace;
+            
             bool scriptsGenerated = false;
             scriptsGenerated |= CreateCollectionItemScript();
             scriptsGenerated |= CreateCollectionScript();
@@ -700,6 +706,9 @@ namespace BrunoMikoski.ScriptableObjectCollections
             ScriptableObjectCollection collectionAsset =
                 ScriptableObjectCollectionUtility.CreateScriptableObjectOfType(targetType, 
                     windowInstance.ScriptableObjectFolderPath, windowInstance.CollectionName) as ScriptableObjectCollection;
+            
+            if (!string.IsNullOrEmpty(LastCollectionNamespace.Value))
+                SOCSettings.Instance.SetNamespaceForCollection(collectionAsset, LastCollectionNamespace.Value);
             
             Selection.objects = new Object[] {collectionAsset};
             EditorGUIUtility.PingObject(collectionAsset);


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/34af822a-f471-4613-9cd8-cdae10810a5d)


Previously when creating a new collection, the `Namespace` field that the collection applies to its generated scripts would default to the namespace prefix, instead of using the same namespace as the collection script itself. Given that by default it places the generated script in the same _folder_ as the as the collection itself, it should also use the same namespace by default, with the option to set it to something else if you prefer.