### PR TITLE
Feature/unity 6 support

### DIFF
--- a/Scripts/Editor/Core/EditorBehaviour.cs
+++ b/Scripts/Editor/Core/EditorBehaviour.cs
@@ -12,7 +12,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
 
         private static void OnPlayModeStateChanged(PlayModeStateChange playModeStateChange)
         {
-            if (playModeStateChange == PlayModeStateChange.EnteredPlayMode)
+            if (playModeStateChange == PlayModeStateChange.ExitingEditMode)
             {                
                 CollectionsRegistry.Instance.RemoveNonAutomaticallyInitializedCollections();
             }

--- a/Scripts/Editor/Core/SOCSettings.cs
+++ b/Scripts/Editor/Core/SOCSettings.cs
@@ -262,10 +262,8 @@ namespace BrunoMikoski.ScriptableObjectCollections
             string path = AssetDatabase.GetAssetPath(collection);
             AssetImporter importer = AssetImporter.GetAtPath(path);
 
-            string collectionSettingsData = importer.userData;
-
             CollectionSettings collectionSetting;
-            if (string.IsNullOrEmpty(collectionSettingsData))
+            if (importer == null || string.IsNullOrEmpty(importer.userData))
             {
                 collectionSetting = new CollectionSettings(collection);
             }

--- a/Scripts/Editor/CustomEditors/CollectionCustomEditor.cs
+++ b/Scripts/Editor/CustomEditors/CollectionCustomEditor.cs
@@ -891,6 +891,18 @@ namespace BrunoMikoski.ScriptableObjectCollections
                 }
             );
 
+            if (selectedItemsCount == 1)
+            {
+                menu.AddItem(
+                    new GUIContent("Rename Asset"),
+                    false,
+                    () =>
+                    {
+                        RenameItemAtIndex(collectionItemListView.selectedIndices.First());
+                    }
+                );
+            }
+
             menu.ShowAsContext();
         }
 

--- a/Scripts/Runtime/Core/CollectionItemIndirectReference.cs
+++ b/Scripts/Runtime/Core/CollectionItemIndirectReference.cs
@@ -85,7 +85,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
 
         private bool TryResolveReference(out TObject result)
         {
-            if (CollectionsRegistry.Instance.TryGetCollectionByGUID(CollectionGUID, out ScriptableObjectCollection<TObject> collection))
+            if (CollectionsRegistry.Instance.TryGetCollectionByGUID(CollectionGUID, out ScriptableObjectCollection collection))
             {
                 if (collection.TryGetItemByGUID(CollectionItemGUID, out ScriptableObject item))
                 {
@@ -103,8 +103,13 @@ namespace BrunoMikoski.ScriptableObjectCollections
 
                         if (!string.IsNullOrEmpty(itemLastKnownName))
                         {
-                            if(collection.TryGetItemByName(itemLastKnownName, out result))
+                            if(collection.TryGetItemByName(itemLastKnownName, out ScriptableObject possibleResult))
                             {
+                                result = possibleResult as TObject;
+                                if (result == null)
+                                {
+                                    return false;
+                                }
                                 SetCollectionItem(result);
                                 return true;
                             }

--- a/Scripts/Runtime/Core/CollectionItemPicker.cs
+++ b/Scripts/Runtime/Core/CollectionItemPicker.cs
@@ -33,7 +33,14 @@ namespace BrunoMikoski.ScriptableObjectCollections.Picker
 
                     for (int i = 0; i < indirectReferences.Count; i++)
                     {
-                        cachedItems.Add(indirectReferences[i].Ref);
+                        CollectionItemIndirectReference<TItemType> collectionItemIndirectReference = indirectReferences[i];
+                        if (!collectionItemIndirectReference.IsValid() || collectionItemIndirectReference.Ref == null)
+                        {
+                            indirectReferences.RemoveAt(i);
+                            continue;
+                        }
+
+                        cachedItems.Add(collectionItemIndirectReference.Ref);
                     }
 
                     isDirty = false;

--- a/Scripts/Runtime/Core/CollectionItemQuery.cs
+++ b/Scripts/Runtime/Core/CollectionItemQuery.cs
@@ -1,0 +1,139 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using UnityEngine;
+
+namespace BrunoMikoski.ScriptableObjectCollections.Picker
+{
+    [Serializable]
+    public class CollectionItemQuery<T>  where T : ScriptableObject, ISOCItem
+    {
+        public enum MatchType
+        {
+            Any = 0,
+            All = 1,
+            NotAny = 2,
+            NotAll = 3,
+        }
+
+        [Serializable]
+        public class QuerySet
+        {
+            [SerializeField]
+            private MatchType matchType;
+            public MatchType MatchType => matchType;
+
+            [SerializeField]
+            private CollectionItemPicker<T> picker;
+            public CollectionItemPicker<T> Picker => picker;
+
+            public override string ToString()
+            {
+                return string.Join(", ", picker.Select(o => o.name));
+            }
+        }
+
+        [SerializeField]
+        private QuerySet[] query = Array.Empty<QuerySet>();
+
+        public bool Matches(params T[] targetItems)
+        {
+            return Matches(targetItems, out _);
+        }
+
+        public bool Matches(IList<T> targetItems)
+        {
+            return Matches(targetItems, out _);
+        }
+
+        public override string ToString()
+        {
+            StringBuilder stringBuilder = new StringBuilder();
+            foreach (var querySet in query)
+            {
+                stringBuilder.Append(querySet.MatchType);
+                stringBuilder.Append(" ");
+                stringBuilder.Append(querySet);
+                stringBuilder.Append(" ");
+            }
+
+            return stringBuilder.ToString();
+        }
+
+        public bool Matches(IList<T> targetItems, out int resultMatchCount)
+        {
+            resultMatchCount = 0;
+
+            if (query.Length == 0)
+                return true;
+
+            for (int i = 0; i < query.Length; i++)
+            {
+                QuerySet querySet = query[i];
+
+                int matchCount = 0;
+                for (int j = 0; j < querySet.Picker.Count; j++)
+                {
+                    T socItem = querySet.Picker[j];
+                    if (!socItem)
+                    {
+                        continue;
+                    }
+                    for (int k = 0; k < targetItems.Count; k++)
+                    {
+                        T item = targetItems[k];
+                        if (!item)
+                        {
+                            continue;
+                        }
+                        if (socItem.GUID.Equals(item.GUID))
+                        {
+                            matchCount++;
+                        }
+                    }
+                }
+
+                resultMatchCount += matchCount;
+
+                switch (querySet.MatchType)
+                {
+                    case MatchType.NotAny:
+                    {
+                        if (matchCount > 0)
+                        {
+                            return false;
+                        }
+                        break;
+                    }
+                    case MatchType.NotAll:
+                    {
+                        if(matchCount == querySet.Picker.Count)
+                        {
+                            return false;
+                        }
+                        break;
+                    }
+                    case MatchType.Any:
+                    {
+                        if (matchCount == 0)
+                        {
+                            return false;
+                        }
+                        break;
+                    }
+                    case MatchType.All:
+                    {
+                        if (matchCount < querySet.Picker.Count)
+                        {
+                            return false;
+                        }
+                        break;
+                    }
+                }
+            }
+
+            return resultMatchCount > 0;
+        }
+    }
+}

--- a/Scripts/Runtime/Core/CollectionItemQuery.cs.meta
+++ b/Scripts/Runtime/Core/CollectionItemQuery.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 1612857925484c12af46b11a31f6da81
+timeCreated: 1732011060


### PR DESCRIPTION
Fix Unity 6 support.

Added new right click to move item between collections https://github.com/brunomikoski/ScriptableObjectCollection/issues/159

Fix null reference on empty collection  https://github.com/brunomikoski/ScriptableObjectCollection/issues/158'

Fix renaming issue https://github.com/brunomikoski/ScriptableObjectCollection/issues/157

Fixed null settings issue https://github.com/brunomikoski/ScriptableObjectCollection/issues/149

Changed event where non automatically loaded items are removed on editor simulation https://github.com/brunomikoski/ScriptableObjectCollection/issues/160


Added new CollectionItemQuery type