### PR TITLE
Fix issue with item rename when moving to new collection

### DIFF
--- a/Scripts/Editor/CustomEditors/CollectionCustomEditor.cs
+++ b/Scripts/Editor/CustomEditors/CollectionCustomEditor.cs
@@ -944,9 +944,12 @@ namespace BrunoMikoski.ScriptableObjectCollections
                 string finalDirectory = hasItemsFolder ? itemsFolderPath : directory;
                 string fileName = Path.GetFileName(itemPath);
 
-                string newPath = AssetDatabase.GenerateUniqueAssetPath(Path.Combine(finalDirectory, fileName));
-
-                AssetDatabase.MoveAsset(itemPath, newPath);
+                string newPath = Path.Combine(finalDirectory, fileName);
+                if(!string.Equals(Path.GetFullPath(itemPath), Path.GetFullPath(newPath), StringComparison.InvariantCultureIgnoreCase))
+                {
+                    newPath = AssetDatabase.GenerateUniqueAssetPath(newPath);
+                    AssetDatabase.MoveAsset(itemPath, newPath);
+                }
             }
 
             AssetDatabase.SaveAssets();


### PR DESCRIPTION
The issues manifested when trying to move an item between collections situated in the same folder. 

Since the item already exists, `AssetDatabase.GenerateUniqueAssetPath(Path.Combine(finalDirectory, fileName));` would generate a new name for the file.