### PR TITLE
Feature/smoother migration to 2 3 0

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ## [2.3.9] - 19/02/2025
 ## Changed
+ - Fixed generated static access code overwriting the collection definition
+ - Pre 2.3.0 collections will now be assumed to want a namespace setting that is the same namespace as its item type
+ - When generating static/indirect access code using the new `.g.cs` suffix, existing static/indirect access code that uses the old `.cs` suffix is now automatically removed to prevent compile errors
+
+## Changed
  - Added some general fixes to validate Collection and Items have unique `LongGuid`
  - Fixed issues when after some operation with the context menu on the CollectionEditor items would not refresh properly
  - Fixed issue when moving items between collection would not generate unique names

--- a/Scripts/Editor/Core/CodeGenerationUtility.cs
+++ b/Scripts/Editor/Core/CodeGenerationUtility.cs
@@ -19,6 +19,8 @@ namespace BrunoMikoski.ScriptableObjectCollections
         private const string PrivateValuesName = "cachedValues";
         private const string PublicValuesName = "Values";
         private const string HasCachedValuesName = "hasCachedValues";
+        private const string ExtensionOld = ".cs";
+        private const string ExtensionNew = ".g.cs";
         
 
         public static bool CreateNewScript(
@@ -339,7 +341,19 @@ namespace BrunoMikoski.ScriptableObjectCollections
             string fileName = $"{collectionName}IndirectReference";
 
             AssetDatabaseUtils.CreatePathIfDoesntExist(targetFolder);
-            using (StreamWriter writer = new StreamWriter(Path.Combine(targetFolder, $"{fileName}.g.cs")))
+            
+            string targetFileName = Path.Combine(targetFolder, fileName);
+            
+            // Delete any existing files that have the old deprecated extension.
+            string deprecatedFileName = targetFileName + ExtensionOld;
+            if (AssetDatabase.AssetPathExists(deprecatedFileName))
+            {
+                Debug.Log($"Supposed to delete deprecated Indirect Access file '{deprecatedFileName}'");
+                AssetDatabase.DeleteAsset(deprecatedFileName);
+            }
+
+            targetFileName += ExtensionNew;
+            using (StreamWriter writer = new StreamWriter(targetFileName))
             {
                 int indentation = 0;
                 List<string> directives = new List<string>();
@@ -385,7 +399,19 @@ namespace BrunoMikoski.ScriptableObjectCollections
 
 
             AssetDatabaseUtils.CreatePathIfDoesntExist(finalFolder);
-            using (StreamWriter writer = new StreamWriter(Path.Combine(finalFolder, $"{fileName}.g.cs")))
+
+            string finalFileName = Path.Combine(finalFolder, fileName);
+            
+            // Delete any existing files that have the old deprecated extension.
+            string deprecatedFileName = finalFileName + ExtensionOld;
+            if (File.Exists(deprecatedFileName))
+            {
+                Debug.Log($"Supposed to delete deprecated Static Access file '{deprecatedFileName}'");
+                AssetDatabase.DeleteAsset(deprecatedFileName);
+            }
+            
+            finalFileName += ExtensionNew;
+            using (StreamWriter writer = new StreamWriter(finalFileName))
             {
                 int indentation = 0;
                 
@@ -629,7 +655,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
         {
             return File.Exists(Path.Combine(
                 AssetDatabase.GetAssetPath(SOCSettings.Instance.GetParentDefaultAssetScriptsFolderForCollection(collection)),
-                $"{SOCSettings.Instance.GetStaticFilenameForCollection(collection)}.g.cs"));
+                $"{SOCSettings.Instance.GetStaticFilenameForCollection(collection)}{ExtensionNew}"));
         }
     }
 }

--- a/Scripts/Editor/Core/CollectionSettings.cs
+++ b/Scripts/Editor/Core/CollectionSettings.cs
@@ -47,7 +47,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
             
             bool canBePartial = CodeGenerationUtility.CheckIfCanBePartial(targetCollection, ParentFolderPath);
             
-            if (!canBePartial)
+            if (canBePartial)
                 StaticFilename = $"{targetCollection.GetType().Name}Static".FirstToUpper();
             else 
                 StaticFilename = $"{targetCollection.GetType().Name}".FirstToUpper();

--- a/Scripts/Editor/Core/CollectionSettings.cs
+++ b/Scripts/Editor/Core/CollectionSettings.cs
@@ -29,7 +29,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
         {
             Guid = targetCollection.GUID;
             string targetNamespace = targetCollection.GetItemType().Namespace;
-            if (!string.IsNullOrEmpty(SOCSettings.Instance.NamespacePrefix))
+            if (string.IsNullOrEmpty(targetNamespace) && !string.IsNullOrEmpty(SOCSettings.Instance.NamespacePrefix))
                 targetNamespace = $"{SOCSettings.Instance.NamespacePrefix}";
             
             Namespace = targetNamespace;


### PR DESCRIPTION
 - Migrating from a version before 2.3.0 to 2.3.0 or newer no longer results in compile errors when you generate static access:
 - Fixed generated static access code overwriting the collection definition
 - Pre `2.3.0` collections will now be assumed to want a namespace setting that is the same namespace as its item type
 - When generating static/indirect access code using the new `.g.cs` suffix, existing static/indirect access code that uses the old `.cs` suffix is now automatically removed to prevent compile errors