### PR TITLE
Fix AssetDatabase.AssetPathExists compatibility for Unity versions before 2023.1

### DIFF
--- a/Scripts/Editor/Core/CodeGenerationUtility.cs
+++ b/Scripts/Editor/Core/CodeGenerationUtility.cs
@@ -346,7 +346,11 @@ namespace BrunoMikoski.ScriptableObjectCollections
             
             // Delete any existing files that have the old deprecated extension.
             string deprecatedFileName = targetFileName + ExtensionOld;
+#if UNITY_2023_1_OR_NEWER
             if (AssetDatabase.AssetPathExists(deprecatedFileName))
+#else
+            if (AssetDatabase.LoadAssetAtPath<UnityEngine.Object>(deprecatedFileName) != null)
+#endif
             {
                 Debug.LogWarning($"Deleting deprecated Indirect Access file '{deprecatedFileName}'.");
                 AssetDatabase.DeleteAsset(deprecatedFileName);


### PR DESCRIPTION
## Summary
This PR fixes a compilation error that occurs when using Unity versions prior to 2023.1 due to the use of `AssetDatabase.AssetPathExists`, which was added in Unity 2023.1.0a4.

## Changes
- Added preprocessor directives to check Unity version
- For Unity 2023.1 and newer: Use `AssetDatabase.AssetPathExists`
- For older versions: Use `AssetDatabase.LoadAssetAtPath<UnityEngine.Object>() != null` as a fallback

## Testing
- Verified that the functionality works correctly on both Unity 2022.3 and 2023.1+