### PR TITLE
Guid Processor + A lot of more things

### DIFF
--- a/.github/instructions.md
+++ b/.github/instructions.md
@@ -1,0 +1,84 @@
+# Scriptable Object Collection — Project Instructions
+
+## Project Overview
+
+This is a **Unity Package** (`com.brunomikoski.scriptableobjectcollection`) that improves the usability of ScriptableObjects by grouping them into collections with code generation, custom inspectors, and GUID-based referencing. It targets **Unity 6000.0+** and is distributed via UPM (Unity Package Manager).
+
+## Language and Runtime
+
+- **C# 9** (Unity's default for Unity 6). Do not use C# 10+ features (e.g., `global using`, file-scoped namespaces, raw string literals).
+- Target **.NET Standard 2.1** APIs only. Do not use APIs exclusive to .NET 5/6/7+.
+- `unsafe` code is **not allowed** (`allowUnsafeCode: false` in assembly definitions).
+- Use `is` and `is not` pattern matching, target-typed `new()`, and null-coalescing where appropriate — these are available in C# 9.
+
+## Project Structure
+
+```
+Scripts/
+  Runtime/       → Runtime assembly (BrunoMikoski.ScriptableObjectCollection)
+  Editor/        → Editor assembly (BrunoMikoski.ScriptableObjectCollection.Editor)
+    Browser/     → Editor Browser sub-assembly
+    Core/        → Settings, code generation, dropdowns
+    CustomEditors/ → Custom Inspector editors
+    Processors/  → Asset post-processors
+    PropertyDrawers/ → Custom property drawers
+    Generators/  → Static code generators
+Samples~/        → UPM samples (ignored by Unity unless imported)
+Documentation~/  → UPM documentation (ignored by Unity at runtime)
+```
+
+- **Runtime code must never reference `UnityEditor`** unless wrapped in `#if UNITY_EDITOR` / `#endif`.
+- Editor-only logic in runtime files must always be inside `#if UNITY_EDITOR` blocks.
+- Assembly definitions (`.asmdef`) define compilation boundaries — do not add cross-assembly references without updating them.
+
+## Code Style and Conventions
+
+### Naming
+- **Namespace**: `BrunoMikoski.ScriptableObjectCollections` (with `s`) for all types. Sub-namespaces: `.Picker`.
+- **Private fields**: `camelCase`, no underscore prefix (e.g., `private LongGuid guid;`).
+- **Properties**: `PascalCase` (e.g., `public LongGuid GUID => guid;`). Acronyms stay uppercase (`GUID`, `SOC`).
+- **Constants**: `UPPER_SNAKE_CASE` for private string constants in editors (e.g., `ITEMS_PROPERTY_NAME`), `PascalCase` for public constants.
+- **Classes**: One class per file. File name matches class name.
+- **Interfaces**: Prefixed with `I` (e.g., `ISOCItem`).
+
+### Formatting
+- 4-space indentation (no tabs).
+- Allman-style braces (opening brace on new line).
+- UTF-8 encoding **without BOM** for all `.cs` files.
+- Normalize line endings (handle both `\r\n` and `\n`).
+
+### Patterns
+- Prefer `for` loops over `foreach` in hot paths and runtime code to avoid enumerator allocations.
+- Use `[SerializeField]` with `private` fields; avoid public serialized fields.
+- Use `[HideInInspector]` for serialized fields that shouldn't appear in the default inspector.
+- Use `[FormerlySerializedAs("oldName")]` when renaming serialized fields to preserve data.
+- Avoid LINQ in runtime hot paths (allocations). LINQ is acceptable in editor code.
+- Cache lookups in dictionaries when collections are iterated frequently (see `itemGuidToScriptableObject`, `itemNameToScriptableObject` patterns).
+- Always validate caches: when returning a cached value, verify it's still valid (not destroyed, GUID still matches) before trusting it. Evict stale entries.
+
+### Unity-Specific
+- Use `ObjectUtility.SetDirty(obj)` instead of calling `EditorUtility.SetDirty` directly (it wraps the editor check).
+- Use `ScriptableObject.CreateInstance<T>()` to instantiate ScriptableObjects, never `new`.
+- Null-check Unity objects carefully: use `.IsNull()` extension or explicit `== null` (Unity overrides `==` for destroyed objects). Standard `is null` does **not** detect destroyed Unity objects.
+- Use `AssetDatabase` APIs only inside `#if UNITY_EDITOR` blocks or in Editor assemblies.
+- Use `TypeCache` in editor code for efficient type lookups instead of reflection-heavy alternatives.
+
+## GUID System
+
+- Items and collections use `LongGuid` (a 128-bit struct, two `long` values) — not Unity's `string` GUIDs.
+- GUID validation and uniqueness is enforced by `SOCItemGuidProcessor` (an asset postprocessor), not at item creation time.
+- When working with GUIDs: always check `guid.IsValid()` before using. Generate new GUIDs with `GenerateNewGUID()`.
+
+## Code Generation
+
+- Generated scripts use UTF-8 without BOM.
+- Line endings are normalized before writing.
+- Generated files use `partial class` and the `new` modifier where appropriate to avoid compiler warnings.
+
+## PR and Review Guidelines
+
+- Keep runtime and editor changes clearly separated.
+- Any new serialized field rename must include `[FormerlySerializedAs]` for backward compatibility.
+- New editor UI should use UXML/UIToolkit where the existing editors do, but IMGUI is acceptable for property drawers.
+- Avoid introducing GC allocations in runtime `Matches()` or lookup methods — reuse collections (see `HashSet` reuse pattern in `CollectionItemQuery`).
+- Conditional compilation (`#if UNITY_EDITOR`, `#if ADDRESSABLES_ENABLED`) must be used correctly; do not assume optional packages are present.

--- a/Scripts/Editor/Core/CodeGenerationUtility.cs
+++ b/Scripts/Editor/Core/CodeGenerationUtility.cs
@@ -61,7 +61,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
             if (File.Exists(Path.GetFullPath(finalFilePath)))
                 return false;
 
-            using StreamWriter writer = new StreamWriter(finalFilePath);
+            using StreamWriter writer = new StreamWriter(finalFilePath, false, new UTF8Encoding(false));
             int indentation = 0;
 
             // First write the directives.
@@ -144,7 +144,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
             }
             
             // Now create the script.
-            string[] lines = codeTemplateText.Split("\r\n");
+            string[] lines = codeTemplateText.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None);
             return CreateNewScript(fileName, parentFolder, nameSpace, directives, lines);
         }
 
@@ -377,12 +377,12 @@ namespace BrunoMikoski.ScriptableObjectCollections
             }
 
             targetFileName += ExtensionNew;
-            using (StreamWriter writer = new StreamWriter(targetFileName))
+            using (StreamWriter writer = new StreamWriter(targetFileName, false, new UTF8Encoding(false)))
             {
                 int indentation = 0;
                 List<string> directives = new List<string>();
                 directives.Add(typeof(ScriptableObjectCollection).Namespace);
-                
+
                 directives.Add(collectionNamespace);
                 directives.Add("System");
                 directives.Add("UnityEngine");
@@ -441,10 +441,10 @@ namespace BrunoMikoski.ScriptableObjectCollections
             }
             
             finalFileName += ExtensionNew;
-            using (StreamWriter writer = new StreamWriter(finalFileName))
+            using (StreamWriter writer = new StreamWriter(finalFileName, false, new UTF8Encoding(false)))
             {
                 int indentation = 0;
-                
+
                 List<string> directives = new List<string>();
                 directives.Add(typeof(CollectionsRegistry).Namespace);
                 directives.Add(collection.GetType().Namespace);

--- a/Scripts/Editor/Core/CodeGenerationUtility.cs
+++ b/Scripts/Editor/Core/CodeGenerationUtility.cs
@@ -564,15 +564,21 @@ namespace BrunoMikoski.ScriptableObjectCollections
 
             Type itemType = collection.GetItemType();
             bool writeAsPartial = SOCSettings.Instance.GetWriteAsPartialClass(collection);
-            bool hasBaseTypeCollection = false;
+            bool baseTypeHasValuesProperty = false;
 
+            // The 'new' modifier is only needed when our item type extends another type that has a generated
+            // Values property (from a base collection using partial class generation). We must not add 'new'
+            // when the base type doesn't have Values - that would cause CS0109 compiler warning.
             if (itemType != null && itemType.BaseType != null)
             {
                 List<ScriptableObjectCollection> baseCollections = CollectionsRegistry.Instance.GetCollectionsByItemType(itemType.BaseType);
-                hasBaseTypeCollection = baseCollections != null && baseCollections.Count > 0;
+                if (baseCollections != null && baseCollections.Count > 0)
+                {
+                    baseTypeHasValuesProperty = baseCollections.Any(c => SOCSettings.Instance.GetWriteAsPartialClass(c));
+                }
             }
 
-            bool addNewModifier = writeAsPartial && hasBaseTypeCollection;
+            bool addNewModifier = writeAsPartial && baseTypeHasValuesProperty;
 
             AppendLine(writer, indentation, $"public {(addNewModifier ? "new " : string.Empty)}static {collection.GetType().FullName} {PublicValuesName}");
             

--- a/Scripts/Editor/Core/CodeGenerationUtility.cs
+++ b/Scripts/Editor/Core/CodeGenerationUtility.cs
@@ -564,18 +564,17 @@ namespace BrunoMikoski.ScriptableObjectCollections
 
             Type itemType = collection.GetItemType();
             bool writeAsPartial = SOCSettings.Instance.GetWriteAsPartialClass(collection);
-            bool baseTypeHasValuesProperty = false;
 
             // The 'new' modifier is only needed when our item type extends another type that has a generated
-            // Values property (from a base collection using partial class generation). We must not add 'new'
-            // when the base type doesn't have Values - that would cause CS0109 compiler warning.
-            if (itemType != null && itemType.BaseType != null)
+            // Values property. That only happens when a collection exists for the *exact* base type (not
+            // derived types) and uses partial generation. GetCollectionsByItemType returns derived
+            // collections too (e.g. CarCollection when querying Vehicle), so we must filter.
+            bool baseTypeHasValuesProperty = false;
+            if (itemType?.BaseType != null)
             {
                 List<ScriptableObjectCollection> baseCollections = CollectionsRegistry.Instance.GetCollectionsByItemType(itemType.BaseType);
-                if (baseCollections != null && baseCollections.Count > 0)
-                {
-                    baseTypeHasValuesProperty = baseCollections.Any(c => SOCSettings.Instance.GetWriteAsPartialClass(c));
-                }
+                baseTypeHasValuesProperty = baseCollections != null && baseCollections.Any(c =>
+                    c.GetItemType() == itemType.BaseType && SOCSettings.Instance.GetWriteAsPartialClass(c));
             }
 
             bool addNewModifier = writeAsPartial && baseTypeHasValuesProperty;

--- a/Scripts/Editor/Core/CollectionItemDropdown.cs
+++ b/Scripts/Editor/Core/CollectionItemDropdown.cs
@@ -162,10 +162,17 @@ namespace BrunoMikoski.ScriptableObjectCollections
             if (item.name.Equals(CREATE_NEW_TEXT, StringComparison.OrdinalIgnoreCase))
             {
                 ScriptableObjectCollection collection = collections.First();
-                ScriptableObject newItem = CollectionCustomEditor.AddNewItem(collection, itemType);
-                callback.Invoke(newItem);
-                
-                InvokeOnSelectCallback(previousValue, newItem);
+                TypeCache.TypeCollection types = TypeCache.GetTypesDerivedFrom(itemType);
+                if (types.Count == 0)
+                {
+                    ScriptableObject newItem = CollectionCustomEditor.AddNewItem(collection, itemType);
+                    callback.Invoke(newItem);
+                    InvokeOnSelectCallback(previousValue, newItem);
+                }
+                else
+                {
+                    Selection.activeObject = collection;
+                }
                 
                 return;
             }

--- a/Scripts/Editor/Core/SOCSettings.cs
+++ b/Scripts/Editor/Core/SOCSettings.cs
@@ -201,7 +201,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
             return GetOrCreateCollectionSettings(collection).UseBaseClassForItems;
         }
         
-        public void SetUsingBaseClassForItems(ScriptableObjectCollection collection, bool useBaseClass)
+        public void SetUseBaseClassForItems(ScriptableObjectCollection collection, bool useBaseClass)
         {
             CollectionSettings settings = GetOrCreateCollectionSettings(collection);
             settings.SetUseBaseClassForItems(useBaseClass);
@@ -299,5 +299,6 @@ namespace BrunoMikoski.ScriptableObjectCollections
             CollectionSettings settings = GetOrCreateCollectionSettings(collection);
             settings.Save();
         }
+
     }
 }

--- a/Scripts/Editor/CustomEditors/CollectionCustomEditor.cs
+++ b/Scripts/Editor/CustomEditors/CollectionCustomEditor.cs
@@ -394,7 +394,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
                 collection.Clear();
             }
 
-            if (!CollectionsRegistry.Instance.IsKnowCollection(collection))
+            if (!CollectionsRegistry.Instance.IsKnownCollection(collection))
                 CollectionsRegistry.Instance.ReloadCollections();
 
             // Need to cache this before the reorderable list is created, because it affects how the list is displayed.

--- a/Scripts/Editor/CustomEditors/CollectionCustomEditor.cs
+++ b/Scripts/Editor/CustomEditors/CollectionCustomEditor.cs
@@ -197,7 +197,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
             useBaseClassForItems.value = SOCSettings.Instance.GetUseBaseClassForItem(collection);
             useBaseClassForItems.RegisterValueChangedCallback(evt =>
             {
-                SOCSettings.Instance.SetUsingBaseClassForItems(collection, evt.newValue);
+                SOCSettings.Instance.SetUseBaseClassForItems(collection, evt.newValue);
             });
 
             TextField staticFileNameTextField = root.Q<TextField>("static-filename-textfield");

--- a/Scripts/Editor/CustomEditors/CollectionCustomEditor.cs
+++ b/Scripts/Editor/CustomEditors/CollectionCustomEditor.cs
@@ -22,6 +22,8 @@ namespace BrunoMikoski.ScriptableObjectCollections
     [CustomEditor(typeof(ScriptableObjectCollection), true)]
     public class CollectionCustomEditor : Editor
     {
+        private const string COLLECTION_EDITOR_UXML_PATH = "Packages/com.brunomikoski.scriptableobjectcollection/Editor/UXML/CollectionCustomEditorTreeAsset.uxml";
+        private const string COLLECTION_ITEM_UXML_PATH = "Packages/com.brunomikoski.scriptableobjectcollection/Editor/UXML/CollectionItemTreeAsset.uxml";
         private const string WAITING_FOR_SCRIPT_TO_BE_CREATED_KEY = "WaitingForScriptTobeCreated";
         private static ScriptableObject LAST_ADDED_COLLECTION_ITEM;
 
@@ -113,6 +115,15 @@ namespace BrunoMikoski.ScriptableObjectCollections
         public override VisualElement CreateInspectorGUI()
         {
             VisualElement root = new();
+            EnsureVisualTreeAssetsAreLoaded();
+            if (visualTreeAsset == null || collectionItemVisualTreeAsset == null)
+            {
+                root.Add(new HelpBox(
+                    "Could not load Collection editor UI assets. Reimport 'com.brunomikoski.scriptableobjectcollection' package or restore missing UXML files.",
+                    HelpBoxMessageType.Error));
+                return root;
+            }
+
             visualTreeAsset.CloneTree(root);
 
             collection = (ScriptableObjectCollection)target;
@@ -254,10 +265,26 @@ namespace BrunoMikoski.ScriptableObjectCollections
             ToolbarSearchField toolbarSearchField = root.Q<ToolbarSearchField>();
             toolbarSearchField.RegisterValueChangedCallback(OnSearchInputChanged);
 
+            IMGUIContainer additionalIMGUIContainer = new IMGUIContainer(DrawAdditionalIMGUI);
+            root.Add(additionalIMGUIContainer);
+
             
             root.schedule.Execute(OnVisualTreeCreated).ExecuteLater(100);
 
             return root;
+        }
+
+        private void EnsureVisualTreeAssetsAreLoaded()
+        {
+            if (visualTreeAsset == null)
+                visualTreeAsset = AssetDatabase.LoadAssetAtPath<VisualTreeAsset>(COLLECTION_EDITOR_UXML_PATH);
+
+            if (collectionItemVisualTreeAsset == null)
+                collectionItemVisualTreeAsset = AssetDatabase.LoadAssetAtPath<VisualTreeAsset>(COLLECTION_ITEM_UXML_PATH);
+        }
+
+        protected virtual void DrawAdditionalIMGUI()
+        {
         }
 
         private void UpdateAutomaticallyLoaded()

--- a/Scripts/Editor/Processors/CollectionsAssetsPostProcessor.cs
+++ b/Scripts/Editor/Processors/CollectionsAssetsPostProcessor.cs
@@ -24,29 +24,6 @@ namespace BrunoMikoski.ScriptableObjectCollections
 
                 Type type = AssetDatabase.GetMainAssetTypeAtPath(importedAssetPath);
 
-                if (typeof(ScriptableObject).IsAssignableFrom(type))
-                {
-                    ScriptableObject collectionItem =
-                        AssetDatabase.LoadAssetAtPath<ScriptableObject>(importedAssetPath);
-
-                    if (collectionItem == null)
-                    {
-                        continue;
-                    }
-
-                    if (collectionItem is not ISOCItem socItem)
-                    {
-                        continue;
-                    }
-
-                    if (!CollectionsRegistry.Instance.HasUniqueGUID(socItem))
-                    {
-                        socItem.GenerateNewGUID();
-                        socItem.ClearCollection();
-                        Debug.LogWarning($"Item {socItem} GUID was not unique, generating a new one and clearing the collection");
-                    }
-                }
-                
                 if (typeof(ScriptableObjectCollection).IsAssignableFrom(type))
                 {
                     ScriptableObjectCollection collection =

--- a/Scripts/Editor/Processors/CollectionsAssetsPostProcessor.cs
+++ b/Scripts/Editor/Processors/CollectionsAssetsPostProcessor.cs
@@ -62,7 +62,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
                         Debug.LogWarning($"Collection {collection} GUID was not unique, generating a new one, and clearing the items");
                     }
 
-                    if (!CollectionsRegistry.Instance.IsKnowCollection(collection))
+                    if (!CollectionsRegistry.Instance.IsKnownCollection(collection))
                     {
                         RefreshRegistry();
                         Debug.Log($"New collection found on the Project {collection.name}, refreshing the Registry");

--- a/Scripts/Editor/Processors/SOCItemGuidProcessor.cs
+++ b/Scripts/Editor/Processors/SOCItemGuidProcessor.cs
@@ -1,0 +1,140 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEditor;
+
+namespace BrunoMikoski.ScriptableObjectCollections
+{
+    internal sealed class SOCItemGuidProcessor : AssetPostprocessor
+    {
+        private static readonly Dictionary<LongGuid, string> PathByGuid = new Dictionary<LongGuid, string>();
+        private static bool indexInitialized;
+
+        [InitializeOnLoadMethod]
+        private static void Initialize()
+        {
+            RebuildIndex();
+            EditorApplication.projectChanged += OnProjectChanged;
+        }
+
+        private static void OnProjectChanged()
+        {
+            RebuildIndex();
+        }
+
+        private static void RebuildIndex()
+        {
+            PathByGuid.Clear();
+            string[] guids = AssetDatabase.FindAssets($"t:{nameof(ScriptableObjectCollectionItem)}");
+            for (int i = 0; i < guids.Length; i++)
+            {
+                string path = AssetDatabase.GUIDToAssetPath(guids[i]);
+                ScriptableObjectCollectionItem item = AssetDatabase.LoadAssetAtPath<ScriptableObjectCollectionItem>(path);
+                if (item == null)
+                    continue;
+
+                LongGuid guid = item.GUID;
+                if (!guid.IsValid())
+                    continue;
+
+                PathByGuid.TryAdd(guid, path);
+            }
+
+            indexInitialized = true;
+        }
+
+        private static bool TryGetOwner(LongGuid guid, out string path)
+        {
+            if (!indexInitialized)
+                RebuildIndex();
+            return PathByGuid.TryGetValue(guid, out path);
+        }
+
+        private static void UpsertIndex(ScriptableObjectCollectionItem item, string path)
+        {
+            if (!indexInitialized)
+                RebuildIndex();
+            LongGuid guid = item.GUID;
+            if (!guid.IsValid())
+                return;
+            PathByGuid[guid] = path;
+        }
+
+        private static void RemoveFromIndex(ScriptableObjectCollectionItem item)
+        {
+            if (!indexInitialized)
+                return;
+            LongGuid guid = item.GUID;
+            if (!guid.IsValid())
+                return;
+            
+            if (PathByGuid.TryGetValue(guid, out string existing) && existing == AssetDatabase.GetAssetPath(item))
+                PathByGuid.Remove(guid);
+        }
+
+        private static void OnPostprocessAllAssets(
+            string[] importedAssets,
+            string[] deletedAssets,
+            string[] movedAssets,
+            string[] movedFromAssetPaths)
+        {
+            bool anyDirty = false;
+
+            foreach (string del in deletedAssets)
+            {
+                ScriptableObjectCollectionItem item = AssetDatabase.LoadAssetAtPath<ScriptableObjectCollectionItem>(del);
+                if (item != null)
+                    RemoveFromIndex(item);
+            }
+
+            foreach (string path in importedAssets)
+            {
+                ScriptableObjectCollectionItem item = AssetDatabase.LoadAssetAtPath<ScriptableObjectCollectionItem>(path);
+                if (item == null)
+                    continue;
+
+                bool changed = EnsureValidAndUniqueGuid(item, path);
+                if (changed)
+                {
+                    EditorUtility.SetDirty(item);
+                    anyDirty = true;
+                }
+
+                UpsertIndex(item, path);
+            }
+
+            for (int i = 0; i < movedAssets.Length; i++)
+            {
+                string newPath = movedAssets[i];
+                ScriptableObjectCollectionItem item = AssetDatabase.LoadAssetAtPath<ScriptableObjectCollectionItem>(newPath);
+                if (item == null)
+                    continue;
+
+                UpsertIndex(item, newPath);
+            }
+
+            if (anyDirty)
+            {
+                AssetDatabase.SaveAssets();
+            }
+        }
+
+        private static bool EnsureValidAndUniqueGuid(ScriptableObjectCollectionItem item, string path)
+        {
+            LongGuid guid = item.GUID;
+
+            if (!guid.IsValid())
+            {
+                item.GenerateNewGUID();
+                return true;
+            }
+
+            if (TryGetOwner(guid, out string ownerPath) && !string.Equals(ownerPath, path, StringComparison.Ordinal))
+            {
+                item.GenerateNewGUID();
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/Scripts/Editor/Processors/SOCItemGuidProcessor.cs
+++ b/Scripts/Editor/Processors/SOCItemGuidProcessor.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using UnityEditor;
 
@@ -66,9 +66,30 @@ namespace BrunoMikoski.ScriptableObjectCollections
             LongGuid guid = item.GUID;
             if (!guid.IsValid())
                 return;
-            
+
             if (PathByGuid.TryGetValue(guid, out string existing) && existing == AssetDatabase.GetAssetPath(item))
                 PathByGuid.Remove(guid);
+        }
+
+        private static void RemoveFromIndexByPath(string path)
+        {
+            if (!indexInitialized)
+                return;
+
+            LongGuid keyToRemove = default;
+            bool found = false;
+            foreach (var kvp in PathByGuid)
+            {
+                if (string.Equals(kvp.Value, path, System.StringComparison.Ordinal))
+                {
+                    keyToRemove = kvp.Key;
+                    found = true;
+                    break;
+                }
+            }
+
+            if (found)
+                PathByGuid.Remove(keyToRemove);
         }
 
         private static void OnPostprocessAllAssets(
@@ -81,9 +102,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
 
             foreach (string del in deletedAssets)
             {
-                ScriptableObjectCollectionItem item = AssetDatabase.LoadAssetAtPath<ScriptableObjectCollectionItem>(del);
-                if (item != null)
-                    RemoveFromIndex(item);
+                RemoveFromIndexByPath(del);
             }
 
             foreach (string path in importedAssets)

--- a/Scripts/Editor/Processors/SOCItemGuidProcessor.cs.meta
+++ b/Scripts/Editor/Processors/SOCItemGuidProcessor.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 388e1c9b303746ffbba91c0119561abb
+timeCreated: 1764895874

--- a/Scripts/Editor/Processors/SOCItemGuidProcessor.cs.meta
+++ b/Scripts/Editor/Processors/SOCItemGuidProcessor.cs.meta
@@ -1,3 +1,3 @@
-﻿fileFormatVersion: 2
+fileFormatVersion: 2
 guid: 388e1c9b303746ffbba91c0119561abb
 timeCreated: 1764895874

--- a/Scripts/Editor/PropertyDrawers/CollectionItemIndirectReferencePropertyDrawer.cs
+++ b/Scripts/Editor/PropertyDrawers/CollectionItemIndirectReferencePropertyDrawer.cs
@@ -13,7 +13,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
         private const string COLLECTION_ITEM_LAST_KNOW_NAME_PROPERTY_PATH = "itemLastKnownName";
         private const string COLLECTION_GUID_VALUE_A_PROPERTY_PATH = "collectionGUIDValueA";
         private const string COLLECTION_GUID_VALUE_B_PROPERTY_PATH = "collectionGUIDValueB";
-        private const string COLLECTION_LAST_KNOW_NAME_PROPERTY_PATH = "collectionLastKnowName";
+        private const string COLLECTION_LAST_KNOW_NAME_PROPERTY_PATH = "collectionLastKnownName";
         
         private Type collectionItemType;
         private CollectionItemPropertyDrawer collectionItemPropertyDrawer;
@@ -23,7 +23,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
         private SerializedProperty itemLastKnowNameSerializedProperty;
         private SerializedProperty collectionGUIDValueASerializedProperty;
         private SerializedProperty collectionGUIDValueBSerializedProperty;
-        private SerializedProperty collectionLastKnowNameSerializedProperty;
+        private SerializedProperty collectionLastKnownNameSerializedProperty;
 
 
         public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
@@ -47,7 +47,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
             itemLastKnowNameSerializedProperty = property.FindPropertyRelative(COLLECTION_ITEM_LAST_KNOW_NAME_PROPERTY_PATH);
             collectionGUIDValueASerializedProperty = property.FindPropertyRelative(COLLECTION_GUID_VALUE_A_PROPERTY_PATH);
             collectionGUIDValueBSerializedProperty = property.FindPropertyRelative(COLLECTION_GUID_VALUE_B_PROPERTY_PATH);
-            collectionLastKnowNameSerializedProperty = property.FindPropertyRelative(COLLECTION_LAST_KNOW_NAME_PROPERTY_PATH);
+            collectionLastKnownNameSerializedProperty = property.FindPropertyRelative(COLLECTION_LAST_KNOW_NAME_PROPERTY_PATH);
 
             TryGetCollectionItem(out ScriptableObject collectionItem);
             

--- a/Scripts/Editor/PropertyDrawers/CollectionItemPickerPropertyDrawer.cs
+++ b/Scripts/Editor/PropertyDrawers/CollectionItemPickerPropertyDrawer.cs
@@ -328,6 +328,27 @@ namespace BrunoMikoski.ScriptableObjectCollections.Picker
 
                 if (!validReference)
                 {
+                    SerializedProperty lastKnownItemNameProperty = elementProperty.FindPropertyRelative("itemLastKnownName");
+                    SerializedProperty lastKnownCollectionNameProperty = elementProperty.FindPropertyRelative("collectionLastKnownName");
+
+                    string lastKnownItemName = lastKnownItemNameProperty != null ? lastKnownItemNameProperty.stringValue : string.Empty;
+                    string lastKnownCollectionName = lastKnownCollectionNameProperty != null ? lastKnownCollectionNameProperty.stringValue : string.Empty;
+
+                    if (!string.IsNullOrEmpty(lastKnownItemName) || !string.IsNullOrEmpty(lastKnownCollectionName))
+                    {
+                        string ownerName = property.serializedObject != null && property.serializedObject.targetObject != null
+                            ? property.serializedObject.targetObject.name
+                            : "Unknown Owner";
+
+                        Debug.LogError(
+                            $"Missing collection item reference in CollectionItemPicker.\n" +
+                            $"Item Tag: '{lastKnownItemName}'\n" +
+                            $"Collection: '{lastKnownCollectionName}'\n" +
+                            $"Owner: '{ownerName}'\n" +
+                            $"Property Path: '{property.propertyPath}'",
+                            property.serializedObject?.targetObject);
+                    }
+
                     indirectReferencesProperty.DeleteArrayElementAtIndex(i);
                     changed = true;
                 }

--- a/Scripts/Editor/PropertyDrawers/CollectionItemPickerPropertyDrawer.cs
+++ b/Scripts/Editor/PropertyDrawers/CollectionItemPickerPropertyDrawer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using BrunoMikoski.ScriptableObjectCollections.Popup;
@@ -328,6 +328,27 @@ namespace BrunoMikoski.ScriptableObjectCollections.Picker
 
                 if (!validReference)
                 {
+                    SerializedProperty lastKnownItemNameProperty = elementProperty.FindPropertyRelative("itemLastKnownName");
+                    SerializedProperty lastKnownCollectionNameProperty = elementProperty.FindPropertyRelative("collectionLastKnowName");
+
+                    string lastKnownItemName = lastKnownItemNameProperty != null ? lastKnownItemNameProperty.stringValue : string.Empty;
+                    string lastKnownCollectionName = lastKnownCollectionNameProperty != null ? lastKnownCollectionNameProperty.stringValue : string.Empty;
+
+                    if (!string.IsNullOrEmpty(lastKnownItemName) || !string.IsNullOrEmpty(lastKnownCollectionName))
+                    {
+                        string ownerName = property.serializedObject != null && property.serializedObject.targetObject != null
+                            ? property.serializedObject.targetObject.name
+                            : "Unknown Owner";
+
+                        Debug.LogError(
+                            $"Missing collection item reference in CollectionItemPicker.\n" +
+                            $"Item Tag: '{lastKnownItemName}'\n" +
+                            $"Collection: '{lastKnownCollectionName}'\n" +
+                            $"Owner: '{ownerName}'\n" +
+                            $"Property Path: '{property.propertyPath}'",
+                            property.serializedObject?.targetObject);
+                    }
+
                     indirectReferencesProperty.DeleteArrayElementAtIndex(i);
                     changed = true;
                 }

--- a/Scripts/Editor/PropertyDrawers/CollectionItemQueryPropertyDrawer.cs
+++ b/Scripts/Editor/PropertyDrawers/CollectionItemQueryPropertyDrawer.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using BrunoMikoski.ScriptableObjectCollections;
 using UnityEditor;
 using UnityEngine;
 
@@ -36,11 +35,9 @@ namespace BrunoMikoski.ScriptableObjectCollections.Picker
                 height += rowHeight + EditorGUIUtility.standardVerticalSpacing * 2f;
             }
 
-            // "Add Rule" button
             height += EditorGUIUtility.singleLineHeight +
                       EditorGUIUtility.standardVerticalSpacing;
 
-            // Optional help box if there are impossible rules
             if (HasImpossibleRules(queryProp))
             {
                 string msg = "This query contains rules that can never be satisfied (conflicting MatchTypes for overlapping items).";
@@ -74,7 +71,6 @@ namespace BrunoMikoski.ScriptableObjectCollections.Picker
 
             if (property.isExpanded && queryProp != null)
             {
-                // Base rect for all children, one level deeper than the foldout header
                 int previousIndent = EditorGUI.indentLevel;
                 EditorGUI.indentLevel = previousIndent + 1;
                 Rect contentRect = EditorGUI.IndentedRect(new Rect(
@@ -101,7 +97,6 @@ namespace BrunoMikoski.ScriptableObjectCollections.Picker
                     Rect rowRect = line;
                     rowRect.height = rowHeight;
 
-                    // Remove button on the far right (one line high)
                     float removeButtonWidth = 20f;
                     Rect removeRect = new Rect(
                         rowRect.xMax - removeButtonWidth,
@@ -109,7 +104,6 @@ namespace BrunoMikoski.ScriptableObjectCollections.Picker
                         removeButtonWidth,
                         EditorGUIUtility.singleLineHeight);
 
-                    // MatchType on the left (single-line height)
                     float matchWidth = 100f;
                     Rect matchRect = new Rect(
                         rowRect.x,
@@ -117,7 +111,6 @@ namespace BrunoMikoski.ScriptableObjectCollections.Picker
                         matchWidth,
                         EditorGUIUtility.singleLineHeight);
 
-                    // Picker takes remaining horizontal space
                     Rect pickerRect = new Rect(
                         matchRect.xMax + 4f,
                         rowRect.y,
@@ -141,7 +134,6 @@ namespace BrunoMikoski.ScriptableObjectCollections.Picker
                     queryProp.DeleteArrayElementAtIndex(indexToRemove);
                 }
 
-                // Add rule button (fills remaining width under the foldout)
                 Rect addButtonRect = new Rect(
                     line.x,
                     line.y,
@@ -161,7 +153,6 @@ namespace BrunoMikoski.ScriptableObjectCollections.Picker
                 line.y += EditorGUIUtility.singleLineHeight +
                           EditorGUIUtility.standardVerticalSpacing;
 
-                // Overall warning if current configuration is impossible
                 if (HasImpossibleRules(queryProp))
                 {
                     Rect helpRect = line;
@@ -175,7 +166,6 @@ namespace BrunoMikoski.ScriptableObjectCollections.Picker
                     line.y += helpHeight + EditorGUIUtility.standardVerticalSpacing;
                 }
 
-                // Human-readable summary of what this query does
                 string summary = BuildSummaryText(queryProp);
                 if (!string.IsNullOrEmpty(summary))
                 {
@@ -218,7 +208,6 @@ namespace BrunoMikoski.ScriptableObjectCollections.Picker
                 }
             }
 
-            // If no constraints or something went wrong, just draw default popup
             if (validValues.Count == 0 || validValues.Count == enumCount)
             {
                 EditorGUI.PropertyField(position, matchTypeProp, GUIContent.none, true);
@@ -227,8 +216,6 @@ namespace BrunoMikoski.ScriptableObjectCollections.Picker
 
             int currentEnumIndex = matchTypeProp.enumValueIndex;
 
-            // Ensure current value is always selectable even if now invalid,
-            // so user can change it back to something valid.
             if (!validValues.Contains(currentEnumIndex))
             {
                 validValues.Add(currentEnumIndex);
@@ -468,11 +455,11 @@ namespace BrunoMikoski.ScriptableObjectCollections.Picker
         {
             // Based on CollectionItemQuery.MatchType enum:
             // 0 = Any, 1 = All, 2 = NotAny, 3 = NotAll
-            bool aPositive = matchA == 0 || matchA == 1;
-            bool bPositive = matchB == 0 || matchB == 1;
+            bool aPositive = matchA is 0 or 1;
+            bool bPositive = matchB is 0 or 1;
 
-            bool aNegative = matchA == 2 || matchA == 3;
-            bool bNegative = matchB == 2 || matchB == 3;
+            bool aNegative = matchA is 2 or 3;
+            bool bNegative = matchB is 2 or 3;
 
             // Treat any combination of positive and negative on overlapping items as impossible.
             // Examples:

--- a/Scripts/Editor/PropertyDrawers/CollectionItemQueryPropertyDrawer.cs
+++ b/Scripts/Editor/PropertyDrawers/CollectionItemQueryPropertyDrawer.cs
@@ -453,24 +453,16 @@ namespace BrunoMikoski.ScriptableObjectCollections.Picker
 
         private static bool IsCombinationImpossible(int matchA, int matchB)
         {
-            // Based on CollectionItemQuery.MatchType enum:
-            // 0 = Any, 1 = All, 2 = NotAny, 3 = NotAll
+            // 0 = Any, 1 = All (positive) | 2 = SomeNot, 3 = None (negative)
+            // Invalid only when the same tag is in a positive and a negative rule.
             bool aPositive = matchA is 0 or 1;
             bool bPositive = matchB is 0 or 1;
-
             bool aNegative = matchA is 2 or 3;
             bool bNegative = matchB is 2 or 3;
 
-            // Treat any combination of positive and negative on overlapping items as impossible.
-            // Examples:
-            // - Any + NotAny
-            // - Any + NotAll
-            // - All + NotAny
-            // - All + NotAll
             if ((aPositive && bNegative) || (aNegative && bPositive))
                 return true;
 
-            // Positive+positive and negative+negative are allowed.
             return false;
         }
     }

--- a/Scripts/Editor/PropertyDrawers/CollectionItemQueryPropertyDrawer.cs
+++ b/Scripts/Editor/PropertyDrawers/CollectionItemQueryPropertyDrawer.cs
@@ -453,14 +453,25 @@ namespace BrunoMikoski.ScriptableObjectCollections.Picker
 
         private static bool IsCombinationImpossible(int matchA, int matchB)
         {
-            // 0 = Any, 1 = All (positive) | 2 = SomeNot, 3 = None (negative)
-            // Invalid only when the same tag is in a positive and a negative rule.
-            bool aPositive = matchA is 0 or 1;
-            bool bPositive = matchB is 0 or 1;
-            bool aNegative = matchA is 2 or 3;
-            bool bNegative = matchB is 2 or 3;
+            // 0 = Any, 1 = All, 2 = SomeNot (forbids any), 3 = None (forbids all)
+            // Only truly impossible when overlapping items can never satisfy both rules:
+            // - All + SomeNot: must have all AND must have none → impossible
+            // - Any + SomeNot: must have at least one AND must have none → impossible
+            // - All + None: must have all AND must not have all → impossible
+            // - Any + None: must have at least one AND must not have all → satisfiable (partial overlap ok)
+            int lo = Mathf.Min(matchA, matchB);
+            int hi = Mathf.Max(matchA, matchB);
 
-            if ((aPositive && bNegative) || (aNegative && bPositive))
+            // All(1) + SomeNot(2)
+            if (lo == 1 && hi == 2)
+                return true;
+
+            // Any(0) + SomeNot(2)
+            if (lo == 0 && hi == 2)
+                return true;
+
+            // All(1) + None(3)
+            if (lo == 1 && hi == 3)
                 return true;
 
             return false;

--- a/Scripts/Editor/PropertyDrawers/CollectionItemQueryPropertyDrawer.cs
+++ b/Scripts/Editor/PropertyDrawers/CollectionItemQueryPropertyDrawer.cs
@@ -1,0 +1,491 @@
+using System.Collections.Generic;
+using BrunoMikoski.ScriptableObjectCollections;
+using UnityEditor;
+using UnityEngine;
+
+namespace BrunoMikoski.ScriptableObjectCollections.Picker
+{
+    [CustomPropertyDrawer(typeof(CollectionItemQuery<>), true)]
+    public class CollectionItemQueryPropertyDrawer : PropertyDrawer
+    {
+        private const string ITEMS_PROPERTY_NAME = "indirectReferences";
+        private const string COLLECTION_ITEM_GUID_VALUE_A = "collectionItemGUIDValueA";
+        private const string COLLECTION_ITEM_GUID_VALUE_B = "collectionItemGUIDValueB";
+        private const string COLLECTION_GUID_VALUE_A = "collectionGUIDValueA";
+        private const string COLLECTION_GUID_VALUE_B = "collectionGUIDValueB";
+
+        public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+        {
+            SerializedProperty queryProp = property.FindPropertyRelative("query");
+            float height = EditorGUIUtility.singleLineHeight; 
+
+            if (!property.isExpanded || queryProp == null)
+                return height;
+
+            height += EditorGUIUtility.standardVerticalSpacing;
+
+            for (int i = 0; i < queryProp.arraySize; i++)
+            {
+                SerializedProperty element = queryProp.GetArrayElementAtIndex(i);
+                SerializedProperty pickerProp = element != null ? element.FindPropertyRelative("picker") : null;
+
+                float rowHeight = EditorGUIUtility.singleLineHeight;
+                if (pickerProp != null)
+                    rowHeight = Mathf.Max(rowHeight, EditorGUI.GetPropertyHeight(pickerProp, GUIContent.none, true));
+
+                height += rowHeight + EditorGUIUtility.standardVerticalSpacing * 2f;
+            }
+
+            // "Add Rule" button
+            height += EditorGUIUtility.singleLineHeight +
+                      EditorGUIUtility.standardVerticalSpacing;
+
+            // Optional help box if there are impossible rules
+            if (HasImpossibleRules(queryProp))
+            {
+                string msg = "This query contains rules that can never be satisfied (conflicting MatchTypes for overlapping items).";
+                float helpHeight = EditorStyles.helpBox.CalcHeight(new GUIContent(msg), EditorGUIUtility.currentViewWidth - 32);
+                height += helpHeight + EditorGUIUtility.standardVerticalSpacing;
+            }
+
+            string summary = BuildSummaryText(queryProp);
+            if (!string.IsNullOrEmpty(summary))
+            {
+                float summaryHeight = EditorStyles.helpBox.CalcHeight(new GUIContent(summary), EditorGUIUtility.currentViewWidth - 32);
+                height += summaryHeight + EditorGUIUtility.standardVerticalSpacing;
+            }
+
+            return height;
+        }
+
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            EditorGUI.BeginProperty(position, label, property);
+
+            SerializedProperty queryProp = property.FindPropertyRelative("query");
+
+            Rect foldoutRect = new Rect(
+                position.x,
+                position.y,
+                position.width,
+                EditorGUIUtility.singleLineHeight);
+
+            property.isExpanded = EditorGUI.Foldout(foldoutRect, property.isExpanded, label, true);
+
+            if (property.isExpanded && queryProp != null)
+            {
+                // Base rect for all children, one level deeper than the foldout header
+                int previousIndent = EditorGUI.indentLevel;
+                EditorGUI.indentLevel = previousIndent + 1;
+                Rect contentRect = EditorGUI.IndentedRect(new Rect(
+                    position.x,
+                    foldoutRect.yMax + EditorGUIUtility.standardVerticalSpacing,
+                    position.width,
+                    position.height));
+                EditorGUI.indentLevel = previousIndent;
+
+                Rect line = contentRect;
+
+                int indexToRemove = -1;
+
+                for (int i = 0; i < queryProp.arraySize; i++)
+                {
+                    SerializedProperty element = queryProp.GetArrayElementAtIndex(i);
+                    SerializedProperty matchTypeProp = element.FindPropertyRelative("matchType");
+                    SerializedProperty pickerProp = element.FindPropertyRelative("picker");
+
+                    float rowHeight = EditorGUIUtility.singleLineHeight;
+                    if (pickerProp != null)
+                        rowHeight = Mathf.Max(rowHeight, EditorGUI.GetPropertyHeight(pickerProp, GUIContent.none, true));
+
+                    Rect rowRect = line;
+                    rowRect.height = rowHeight;
+
+                    // Remove button on the far right (one line high)
+                    float removeButtonWidth = 20f;
+                    Rect removeRect = new Rect(
+                        rowRect.xMax - removeButtonWidth,
+                        rowRect.y,
+                        removeButtonWidth,
+                        EditorGUIUtility.singleLineHeight);
+
+                    // MatchType on the left (single-line height)
+                    float matchWidth = 100f;
+                    Rect matchRect = new Rect(
+                        rowRect.x,
+                        rowRect.y,
+                        matchWidth,
+                        EditorGUIUtility.singleLineHeight);
+
+                    // Picker takes remaining horizontal space
+                    Rect pickerRect = new Rect(
+                        matchRect.xMax + 4f,
+                        rowRect.y,
+                        rowRect.xMax - matchRect.xMax - removeButtonWidth - 6f,
+                        rowHeight);
+
+                    DrawConstrainedMatchType(matchRect, matchTypeProp, queryProp, i);
+                    if (pickerProp != null)
+                        EditorGUI.PropertyField(pickerRect, pickerProp, GUIContent.none, true);
+
+                    if (GUI.Button(removeRect, "-"))
+                    {
+                        indexToRemove = i;
+                    }
+
+                    line.y = rowRect.y + rowHeight + EditorGUIUtility.standardVerticalSpacing * 2f;
+                }
+
+                if (indexToRemove >= 0 && indexToRemove < queryProp.arraySize)
+                {
+                    queryProp.DeleteArrayElementAtIndex(indexToRemove);
+                }
+
+                // Add rule button (fills remaining width under the foldout)
+                Rect addButtonRect = new Rect(
+                    line.x,
+                    line.y,
+                    contentRect.width,
+                    EditorGUIUtility.singleLineHeight);
+
+                if (GUI.Button(addButtonRect, "Add Rule"))
+                {
+                    int newIndex = queryProp.arraySize;
+                    queryProp.arraySize++;
+                    SerializedProperty newElement = queryProp.GetArrayElementAtIndex(newIndex);
+                    SerializedProperty newMatchType = newElement.FindPropertyRelative("matchType");
+                    if (newMatchType != null)
+                        newMatchType.enumValueIndex = 0; // default to first enum value
+                }
+
+                line.y += EditorGUIUtility.singleLineHeight +
+                          EditorGUIUtility.standardVerticalSpacing;
+
+                // Overall warning if current configuration is impossible
+                if (HasImpossibleRules(queryProp))
+                {
+                    Rect helpRect = line;
+                    string msg = "This query contains rules that can never be satisfied (conflicting MatchTypes for overlapping items).";
+                    float helpHeight = EditorStyles.helpBox.CalcHeight(new GUIContent(msg), contentRect.width);
+                    helpRect.height = helpHeight;
+                    EditorGUI.HelpBox(
+                        helpRect,
+                        msg,
+                        MessageType.Error);
+                    line.y += helpHeight + EditorGUIUtility.standardVerticalSpacing;
+                }
+
+                // Human-readable summary of what this query does
+                string summary = BuildSummaryText(queryProp);
+                if (!string.IsNullOrEmpty(summary))
+                {
+                    Rect summaryRect = line;
+                    float summaryHeight = EditorStyles.helpBox.CalcHeight(new GUIContent(summary), contentRect.width);
+                    summaryRect.height = summaryHeight;
+
+                    EditorGUI.HelpBox(summaryRect, summary, MessageType.Info);
+                    line.y += summaryHeight + EditorGUIUtility.standardVerticalSpacing;
+                }
+            }
+
+            EditorGUI.EndProperty();
+        }
+
+        private void DrawConstrainedMatchType(
+            Rect position,
+            SerializedProperty matchTypeProp,
+            SerializedProperty queryProp,
+            int elementIndex)
+        {
+            if (matchTypeProp == null)
+            {
+                EditorGUI.LabelField(position, "Invalid MatchType");
+                return;
+            }
+
+            string[] allNames = matchTypeProp.enumDisplayNames;
+            int enumCount = allNames.Length;
+
+            List<int> validValues = new List<int>();
+            List<string> validNames = new List<string>();
+
+            for (int enumIndex = 0; enumIndex < enumCount; enumIndex++)
+            {
+                if (IsMatchTypeValid(queryProp, elementIndex, enumIndex))
+                {
+                    validValues.Add(enumIndex);
+                    validNames.Add(allNames[enumIndex]);
+                }
+            }
+
+            // If no constraints or something went wrong, just draw default popup
+            if (validValues.Count == 0 || validValues.Count == enumCount)
+            {
+                EditorGUI.PropertyField(position, matchTypeProp, GUIContent.none, true);
+                return;
+            }
+
+            int currentEnumIndex = matchTypeProp.enumValueIndex;
+
+            // Ensure current value is always selectable even if now invalid,
+            // so user can change it back to something valid.
+            if (!validValues.Contains(currentEnumIndex))
+            {
+                validValues.Add(currentEnumIndex);
+                validNames.Add(allNames[currentEnumIndex] + " (invalid)");
+            }
+
+            int newEnumIndex = EditorGUI.IntPopup(
+                position,
+                currentEnumIndex,
+                validNames.ToArray(),
+                validValues.ToArray());
+
+            matchTypeProp.enumValueIndex = newEnumIndex;
+        }
+
+        private bool IsMatchTypeValid(SerializedProperty queryProp, int elementIndex, int candidateEnumIndex)
+        {
+            if (queryProp == null || queryProp.arraySize == 0)
+                return true;
+
+            // Build item set for the candidate element
+            if (!TryGetElementAndItems(queryProp, elementIndex, out SerializedProperty candidateElement, out HashSet<(long, long)> candidateItems))
+                return true;
+
+            for (int i = 0; i < queryProp.arraySize; i++)
+            {
+                if (i == elementIndex)
+                    continue;
+
+                if (!TryGetElementAndItems(queryProp, i, out SerializedProperty otherElement, out HashSet<(long, long)> otherItems))
+                    continue;
+
+                if (!HasItemIntersection(candidateItems, otherItems))
+                    continue;
+
+                SerializedProperty otherMatchTypeProp = otherElement.FindPropertyRelative("matchType");
+                if (otherMatchTypeProp == null)
+                    continue;
+
+                int otherEnumIndex = otherMatchTypeProp.enumValueIndex;
+
+                if (IsCombinationImpossible(candidateEnumIndex, otherEnumIndex))
+                    return false;
+            }
+
+            return true;
+        }
+
+        private bool HasImpossibleRules(SerializedProperty queryProp)
+        {
+            if (queryProp == null || queryProp.arraySize <= 1)
+                return false;
+
+            for (int i = 0; i < queryProp.arraySize; i++)
+            {
+                if (!TryGetElementAndItems(queryProp, i, out SerializedProperty elementA, out HashSet<(long, long)> itemsA))
+                    continue;
+
+                SerializedProperty matchTypeAProp = elementA.FindPropertyRelative("matchType");
+                if (matchTypeAProp == null)
+                    continue;
+                int matchA = matchTypeAProp.enumValueIndex;
+
+                for (int j = i + 1; j < queryProp.arraySize; j++)
+                {
+                    if (!TryGetElementAndItems(queryProp, j, out SerializedProperty elementB, out HashSet<(long, long)> itemsB))
+                        continue;
+
+                    if (!HasItemIntersection(itemsA, itemsB))
+                        continue;
+
+                    SerializedProperty matchTypeBProp = elementB.FindPropertyRelative("matchType");
+                    if (matchTypeBProp == null)
+                        continue;
+                    int matchB = matchTypeBProp.enumValueIndex;
+
+                    if (IsCombinationImpossible(matchA, matchB))
+                        return true;
+                }
+            }
+
+            return false;
+        }
+
+        private string BuildSummaryText(SerializedProperty queryProp)
+        {
+            if (queryProp == null || queryProp.arraySize == 0)
+                return string.Empty;
+
+            List<string> parts = new List<string>();
+
+            for (int i = 0; i < queryProp.arraySize; i++)
+            {
+                if (!TryGetElementAndItems(queryProp, i, out SerializedProperty element, out HashSet<(long, long)> items))
+                    continue;
+
+                List<string> itemNames = GetItemNamesFromElement(element);
+                if (itemNames.Count == 0)
+                    continue;
+
+                SerializedProperty matchTypeProp = element.FindPropertyRelative("matchType");
+                if (matchTypeProp == null)
+                    continue;
+
+                int matchIndex = matchTypeProp.enumValueIndex;
+
+                string joinedNames = "{" + string.Join(", ", itemNames) + "}";
+
+                string ruleDescription = matchIndex switch
+                {
+                    0 => $"allows objects that contain at least one of {joinedNames}",
+                    1 => $"requires objects to contain all of {joinedNames}",
+                    2 => $"forbids objects that contain any of {joinedNames}",
+                    3 => $"forbids objects that contain all of {joinedNames} together",
+                    _ => null
+                };
+
+                if (!string.IsNullOrEmpty(ruleDescription))
+                    parts.Add(ruleDescription);
+            }
+
+            if (parts.Count == 0)
+                return string.Empty;
+
+            return "This query: " + string.Join(" and ", parts) + ".";
+        }
+
+        private bool TryGetElementAndItems(
+            SerializedProperty queryProp,
+            int index,
+            out SerializedProperty element,
+            out HashSet<(long, long)> items)
+        {
+            element = null;
+            items = null;
+
+            if (queryProp == null || index < 0 || index >= queryProp.arraySize)
+                return false;
+
+            element = queryProp.GetArrayElementAtIndex(index);
+            if (element == null)
+                return false;
+
+            SerializedProperty pickerProp = element.FindPropertyRelative("picker");
+            if (pickerProp == null)
+                return false;
+
+            items = new HashSet<(long, long)>();
+            SerializedProperty itemsProp = pickerProp.FindPropertyRelative(ITEMS_PROPERTY_NAME);
+            if (itemsProp == null)
+                return true; // no items, but still valid
+
+            for (int i = 0; i < itemsProp.arraySize; i++)
+            {
+                SerializedProperty elem = itemsProp.GetArrayElementAtIndex(i);
+                if (elem == null)
+                    continue;
+
+                SerializedProperty guidAProp = elem.FindPropertyRelative(COLLECTION_ITEM_GUID_VALUE_A);
+                SerializedProperty guidBProp = elem.FindPropertyRelative(COLLECTION_ITEM_GUID_VALUE_B);
+
+                if (guidAProp == null || guidBProp == null)
+                    continue;
+
+                long a = guidAProp.longValue;
+                long b = guidBProp.longValue;
+
+                items.Add((a, b));
+            }
+
+            return true;
+        }
+
+        private List<string> GetItemNamesFromElement(SerializedProperty element)
+        {
+            List<string> result = new List<string>();
+            if (element == null)
+                return result;
+
+            SerializedProperty pickerProp = element.FindPropertyRelative("picker");
+            if (pickerProp == null)
+                return result;
+
+            SerializedProperty itemsProp = pickerProp.FindPropertyRelative(ITEMS_PROPERTY_NAME);
+            if (itemsProp == null)
+                return result;
+
+            for (int i = 0; i < itemsProp.arraySize; i++)
+            {
+                SerializedProperty elem = itemsProp.GetArrayElementAtIndex(i);
+                if (elem == null)
+                    continue;
+
+                SerializedProperty collectionGuidAProp = elem.FindPropertyRelative(COLLECTION_GUID_VALUE_A);
+                SerializedProperty collectionGuidBProp = elem.FindPropertyRelative(COLLECTION_GUID_VALUE_B);
+                SerializedProperty itemGuidAProp = elem.FindPropertyRelative(COLLECTION_ITEM_GUID_VALUE_A);
+                SerializedProperty itemGuidBProp = elem.FindPropertyRelative(COLLECTION_ITEM_GUID_VALUE_B);
+
+                if (collectionGuidAProp == null || collectionGuidBProp == null ||
+                    itemGuidAProp == null || itemGuidBProp == null)
+                    continue;
+
+                LongGuid collectionGuid = new LongGuid(collectionGuidAProp.longValue, collectionGuidBProp.longValue);
+                LongGuid itemGuid = new LongGuid(itemGuidAProp.longValue, itemGuidBProp.longValue);
+
+                if (!collectionGuid.IsValid() || !itemGuid.IsValid())
+                    continue;
+
+                if (!CollectionsRegistry.Instance.TryGetCollectionByGUID(collectionGuid, out ScriptableObjectCollection collection))
+                    continue;
+
+                if (!collection.TryGetItemByGUID(itemGuid, out ScriptableObject item))
+                    continue;
+
+                if (item != null && !string.IsNullOrEmpty(item.name))
+                    result.Add(item.name);
+            }
+
+            return result;
+        }
+
+        private static bool HasItemIntersection(HashSet<(long, long)> a, HashSet<(long, long)> b)
+        {
+            if (a == null || b == null || a.Count == 0 || b.Count == 0)
+                return false;
+
+            foreach ((long, long) item in a)
+            {
+                if (b.Contains(item))
+                    return true;
+            }
+
+            return false;
+        }
+
+        private static bool IsCombinationImpossible(int matchA, int matchB)
+        {
+            // Based on CollectionItemQuery.MatchType enum:
+            // 0 = Any, 1 = All, 2 = NotAny, 3 = NotAll
+            bool aPositive = matchA == 0 || matchA == 1;
+            bool bPositive = matchB == 0 || matchB == 1;
+
+            bool aNegative = matchA == 2 || matchA == 3;
+            bool bNegative = matchB == 2 || matchB == 3;
+
+            // Treat any combination of positive and negative on overlapping items as impossible.
+            // Examples:
+            // - Any + NotAny
+            // - Any + NotAll
+            // - All + NotAny
+            // - All + NotAll
+            if ((aPositive && bNegative) || (aNegative && bPositive))
+                return true;
+
+            // Positive+positive and negative+negative are allowed.
+            return false;
+        }
+    }
+}
+

--- a/Scripts/Editor/PropertyDrawers/CollectionItemQueryPropertyDrawer.cs.meta
+++ b/Scripts/Editor/PropertyDrawers/CollectionItemQueryPropertyDrawer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6039275af6647fd4893423d9713e7136

--- a/Scripts/Runtime/Core/CollectionItemIndirectReference.cs
+++ b/Scripts/Runtime/Core/CollectionItemIndirectReference.cs
@@ -21,8 +21,8 @@ namespace BrunoMikoski.ScriptableObjectCollections
 
         [SerializeField]
         protected string itemLastKnownName;
-        [SerializeField]
-        protected string collectionLastKnowName;
+        [SerializeField, FormerlySerializedAs("collectionLastKnowName")]
+        protected string collectionLastKnownName;
 
         public bool Equals(CollectionItemIndirectReference other)
         {
@@ -110,9 +110,9 @@ namespace BrunoMikoski.ScriptableObjectCollections
             }
             else
             {
-                if (!string.IsNullOrEmpty(collectionLastKnowName))
+                if (!string.IsNullOrEmpty(collectionLastKnownName))
                 {
-                    if (CollectionsRegistry.Instance.TryGetCollectionByName(collectionLastKnowName, out collection))
+                    if (CollectionsRegistry.Instance.TryGetCollectionByName(collectionLastKnownName, out collection))
                     {
                         SetCollection(collection);
 
@@ -165,7 +165,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
             (long,long) collectionGUIDValues = targetCollection.GUID.GetRawValues();
             collectionGUIDValueA = collectionGUIDValues.Item1;
             collectionGUIDValueB = collectionGUIDValues.Item2;
-            collectionLastKnowName = targetCollection.name;
+            collectionLastKnownName = targetCollection.name;
         }
     }
 }

--- a/Scripts/Runtime/Core/CollectionItemIndirectReference.cs
+++ b/Scripts/Runtime/Core/CollectionItemIndirectReference.cs
@@ -1,5 +1,6 @@
 using System;
 using UnityEngine;
+using UnityEngine.Serialization;
 
 namespace BrunoMikoski.ScriptableObjectCollections
 {
@@ -68,17 +69,19 @@ namespace BrunoMikoski.ScriptableObjectCollections
         where TObject : ScriptableObject, ISOCItem
     {
         [NonSerialized]
+        private bool hasCachedRef;
+        [NonSerialized]
         private TObject cachedRef;
         public TObject Ref
         {
             get
             {
-                if (cachedRef != null)
+                if (hasCachedRef && cachedRef != null)
                     return cachedRef;
 
-                if (TryResolveReference(out TObject resultObj))
-                    cachedRef = resultObj;
-                
+                hasCachedRef = TryResolveReference(out TObject resultObj);
+                cachedRef = resultObj;
+
                 return cachedRef;
             }
         }

--- a/Scripts/Runtime/Core/CollectionItemPicker.cs
+++ b/Scripts/Runtime/Core/CollectionItemPicker.cs
@@ -31,7 +31,7 @@ namespace BrunoMikoski.ScriptableObjectCollections.Picker
                 {
                     cachedItems.Clear();
 
-                    for (int i = 0; i < indirectReferences.Count; i++)
+                    for (int i = indirectReferences.Count - 1; i >= 0; i--)
                     {
                         CollectionItemIndirectReference<TItemType> collectionItemIndirectReference = indirectReferences[i];
                         if (!collectionItemIndirectReference.IsValid() || collectionItemIndirectReference.Ref == null)
@@ -42,6 +42,8 @@ namespace BrunoMikoski.ScriptableObjectCollections.Picker
 
                         cachedItems.Add(collectionItemIndirectReference.Ref);
                     }
+
+                    cachedItems.Reverse();
 
                     isDirty = false;
                 }

--- a/Scripts/Runtime/Core/CollectionItemQuery.cs
+++ b/Scripts/Runtime/Core/CollectionItemQuery.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -7,14 +7,14 @@ using UnityEngine;
 namespace BrunoMikoski.ScriptableObjectCollections.Picker
 {
     [Serializable]
-    public class CollectionItemQuery<T>  where T : ScriptableObject, ISOCItem
+    public class CollectionItemQuery<T> where T : ScriptableObject, ISOCItem
     {
         public enum MatchType
         {
             Any = 0,
             All = 1,
-            NotAny = 2,
-            NotAll = 3,
+            SomeNot = 2,
+            None = 3,
         }
 
         [Serializable]
@@ -94,13 +94,13 @@ namespace BrunoMikoski.ScriptableObjectCollections.Picker
 
                 switch (qs.MatchType)
                 {
-                    case MatchType.NotAny:
+                    case MatchType.SomeNot:
                     {
                         if (matchCount > 0) 
                             return false;
                         break;
                     }
-                    case MatchType.NotAll:
+                    case MatchType.None:
                     {
                         if (matchCount == pickerCount) 
                             return false; 
@@ -114,7 +114,8 @@ namespace BrunoMikoski.ScriptableObjectCollections.Picker
                     }
                     case MatchType.All:
                     {
-                        if (matchCount < pickerCount) return false; 
+                        if (matchCount < pickerCount) 
+                            return false; 
                         break;
 
                     }

--- a/Scripts/Runtime/Core/CollectionItemQuery.cs
+++ b/Scripts/Runtime/Core/CollectionItemQuery.cs
@@ -37,6 +37,8 @@ namespace BrunoMikoski.ScriptableObjectCollections.Picker
         [SerializeField]
         private QuerySet[] query = Array.Empty<QuerySet>();
 
+        private HashSet<LongGuid> targetGuids = new HashSet<LongGuid>(128);
+
         public bool Matches(params T[] targetItems)
         {
             return Matches(targetItems, out _);
@@ -63,7 +65,7 @@ namespace BrunoMikoski.ScriptableObjectCollections.Picker
 
         public bool Matches(IEnumerable<T> targetItems, out int resultMatchCount)
         {
-            HashSet<LongGuid> targetGuids = new HashSet<LongGuid>();
+            targetGuids.Clear();
             foreach (T item in targetItems)
             {
                 if (item) 

--- a/Scripts/Runtime/Core/CollectionsRegistry.cs
+++ b/Scripts/Runtime/Core/CollectionsRegistry.cs
@@ -473,7 +473,9 @@ namespace BrunoMikoski.ScriptableObjectCollections
                     if (!guid.IsValid())
                     {
                         item.GenerateNewGUID();
+#if UNITY_EDITOR
                         EditorUtility.SetDirty((UnityEngine.Object)item);
+#endif
                         changed = true;
                         Debug.LogWarning($"[SOC] Fixing Invalid GUID on item {item} in collection {collection}");
                         continue;
@@ -482,15 +484,19 @@ namespace BrunoMikoski.ScriptableObjectCollections
                     if (!seen.Add(guid))
                     {
                         item.GenerateNewGUID();
+#if UNITY_EDITOR
                         EditorUtility.SetDirty((UnityEngine.Object)item);
+#endif
                         changed = true;
                         Debug.LogWarning($"[SOC] Fixing Duplicate GUID on item {item} in collection {collection}");
                     }
                 }
             }
-
+            
+#if UNITY_EDITOR
             if (changed)
                 AssetDatabase.SaveAssets();
+#endif
         }
 
         public void SetAutoSearchForCollections(bool isOn)

--- a/Scripts/Runtime/Core/CollectionsRegistry.cs
+++ b/Scripts/Runtime/Core/CollectionsRegistry.cs
@@ -226,7 +226,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
             {
                 ScriptableObjectCollection col = collections[i];
                 Type collectionItemType = col.GetItemType();
-                if (collectionItemType != null && targetCollectionItemType.IsAssignableFrom(collectionItemType))
+                if (collectionItemType != null && (targetCollectionItemType.IsAssignableFrom(collectionItemType) || collectionItemType.IsAssignableFrom(targetCollectionItemType)))
                 {
                     result.Add(col);
                 }

--- a/Scripts/Runtime/Core/CollectionsRegistry.cs
+++ b/Scripts/Runtime/Core/CollectionsRegistry.cs
@@ -250,8 +250,13 @@ namespace BrunoMikoski.ScriptableObjectCollections
             if (collectionGuidLookup.Count == 0 && collections.Count > 0)
                 RebuildGuidLookup();
 
-            if (collectionGuidLookup.TryGetValue(guid, out ScriptableObjectCollection cached) && cached != null)
-                return cached;
+            if (collectionGuidLookup.TryGetValue(guid, out ScriptableObjectCollection cached))
+            {
+                if (cached != null && cached.GUID == guid)
+                    return cached;
+
+                collectionGuidLookup.Remove(guid);
+            }
 
             for (int i = 0; i < collections.Count; i++)
             {

--- a/Scripts/Runtime/Core/CollectionsRegistry.cs
+++ b/Scripts/Runtime/Core/CollectionsRegistry.cs
@@ -226,7 +226,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
             {
                 ScriptableObjectCollection col = collections[i];
                 Type collectionItemType = col.GetItemType();
-                if (collectionItemType != null && collectionItemType.IsAssignableFrom(targetCollectionItemType))
+                if (collectionItemType != null && targetCollectionItemType.IsAssignableFrom(collectionItemType))
                 {
                     result.Add(col);
                 }

--- a/Scripts/Runtime/Core/CollectionsRegistry.cs
+++ b/Scripts/Runtime/Core/CollectionsRegistry.cs
@@ -31,7 +31,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
             LoadOrCreateInstance<CollectionsRegistry>();
         }
 
-        public bool IsKnowCollection(ScriptableObjectCollection targetCollection)
+        public bool IsKnownCollection(ScriptableObjectCollection targetCollection)
         {
             for (int i = 0; i < collections.Count; i++)
             {

--- a/Scripts/Runtime/Core/CollectionsRegistry.cs
+++ b/Scripts/Runtime/Core/CollectionsRegistry.cs
@@ -20,7 +20,9 @@ namespace BrunoMikoski.ScriptableObjectCollections
         [SerializeField]
         private List<ScriptableObjectCollection> collections = new List<ScriptableObjectCollection>();
         public IReadOnlyList<ScriptableObjectCollection> Collections => collections;
-        
+
+        private Dictionary<LongGuid, ScriptableObjectCollection> collectionGuidLookup = new();
+
         [SerializeField, HideInInspector]
         private bool autoSearchForCollections;
         public bool AutoSearchForCollections => autoSearchForCollections;
@@ -47,9 +49,10 @@ namespace BrunoMikoski.ScriptableObjectCollections
         {
             if (collections.Contains(targetCollection))
                 return;
-            
+
             collections.Add(targetCollection);
-            
+            RebuildGuidLookup();
+
             ObjectUtility.SetDirty(this);
         }
 
@@ -60,7 +63,8 @@ namespace BrunoMikoski.ScriptableObjectCollections
 
             if (!collections.Remove(targetCollection))
                 return;
-            
+
+            RebuildGuidLookup();
             ObjectUtility.SetDirty(this);
         }
 
@@ -243,13 +247,33 @@ namespace BrunoMikoski.ScriptableObjectCollections
 
         public ScriptableObjectCollection GetCollectionByGUID(LongGuid guid)
         {
+            if (collectionGuidLookup.Count == 0 && collections.Count > 0)
+                RebuildGuidLookup();
+
+            if (collectionGuidLookup.TryGetValue(guid, out ScriptableObjectCollection cached) && cached != null)
+                return cached;
+
             for (int i = 0; i < collections.Count; i++)
             {
                 if (collections[i] != null && collections[i].GUID == guid)
+                {
+                    collectionGuidLookup[guid] = collections[i];
                     return collections[i];
+                }
             }
 
             return null;
+        }
+
+        private void RebuildGuidLookup()
+        {
+            collectionGuidLookup.Clear();
+            for (int i = 0; i < collections.Count; i++)
+            {
+                ScriptableObjectCollection collection = collections[i];
+                if (collection != null && collection.GUID.IsValid())
+                    collectionGuidLookup[collection.GUID] = collection;
+            }
         }
         
         public bool TryGetCollectionOfType(Type type, out ScriptableObjectCollection resultCollection)
@@ -377,6 +401,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
             {
                 ValidateCollections();
                 collections = foundCollections;
+                RebuildGuidLookup();
                 ObjectUtility.SetDirty(this);
             }
 #endif

--- a/Scripts/Runtime/Core/ScriptableObjectCollection.cs
+++ b/Scripts/Runtime/Core/ScriptableObjectCollection.cs
@@ -444,7 +444,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
                         Clear();
                     }
 
-                    if (!CollectionsRegistry.Instance.IsKnowCollection(this))
+                    if (!CollectionsRegistry.Instance.IsKnownCollection(this))
                     {
                         CollectionsRegistry.Instance.RegisterCollection(this);
                     }

--- a/Scripts/Runtime/Core/ScriptableObjectCollection.cs
+++ b/Scripts/Runtime/Core/ScriptableObjectCollection.cs
@@ -46,6 +46,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
         public virtual bool ShouldProtectItemOrder => false;
         
         private Dictionary<string,ScriptableObject> itemNameToScriptableObject = new();
+        private Dictionary<LongGuid,ScriptableObject> itemGuidToScriptableObject = new();
 
         public ScriptableObject this[int index]
         {
@@ -468,10 +469,13 @@ namespace BrunoMikoski.ScriptableObjectCollections
         public void CacheItemNames()
         {
             itemNameToScriptableObject.Clear();
+            itemGuidToScriptableObject.Clear();
             for (int i = 0; i < items.Count; i++)
             {
                 ScriptableObject item = items[i];
                 itemNameToScriptableObject.TryAdd(item.name, item);
+                if (item is ISOCItem socItem && socItem.GUID.IsValid())
+                    itemGuidToScriptableObject.TryAdd(socItem.GUID, item);
             }
         }
         
@@ -499,16 +503,23 @@ namespace BrunoMikoski.ScriptableObjectCollections
         {
             if (itemGUID.IsValid())
             {
+                if (itemGuidToScriptableObject.TryGetValue(itemGUID, out ScriptableObject cached))
+                {
+                    scriptableObjectCollectionItem = cached as T;
+                    return scriptableObjectCollectionItem != null;
+                }
+
                 for (int i = 0; i < items.Count; i++)
                 {
                     ScriptableObject item = items[i];
                     ISOCItem socItem = item as ISOCItem;
                     if (socItem == null)
                         continue;
-                
+
                     if (socItem.GUID == itemGUID)
                     {
                         scriptableObjectCollectionItem = item as T;
+                        itemGuidToScriptableObject[itemGUID] = item;
                         return scriptableObjectCollectionItem != null;
                     }
                 }
@@ -524,6 +535,8 @@ namespace BrunoMikoski.ScriptableObjectCollections
 
         protected virtual void ClearCachedValues()
         {
+            itemGuidToScriptableObject.Clear();
+            itemNameToScriptableObject.Clear();
         }
     }
 
@@ -546,8 +559,6 @@ namespace BrunoMikoski.ScriptableObjectCollections
             get => (TObjectType)base[index];
             set => base[index] = value;
         }
-        
-        private readonly Dictionary<Type, List<TObjectType>> typeToItems = new();
 
 
         public new IEnumerator<TObjectType> GetEnumerator()

--- a/Scripts/Runtime/Core/ScriptableObjectCollection.cs
+++ b/Scripts/Runtime/Core/ScriptableObjectCollection.cs
@@ -505,8 +505,13 @@ namespace BrunoMikoski.ScriptableObjectCollections
             {
                 if (itemGuidToScriptableObject.TryGetValue(itemGUID, out ScriptableObject cached))
                 {
-                    scriptableObjectCollectionItem = cached as T;
-                    return scriptableObjectCollectionItem != null;
+                    if (cached != null && cached is ISOCItem cachedSocItem && cachedSocItem.GUID == itemGUID)
+                    {
+                        scriptableObjectCollectionItem = cached as T;
+                        return scriptableObjectCollectionItem != null;
+                    }
+
+                    itemGuidToScriptableObject.Remove(itemGUID);
                 }
 
                 for (int i = 0; i < items.Count; i++)
@@ -719,6 +724,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
 
         protected override void ClearCachedValues()
         {
+            base.ClearCachedValues();
             cachedValues = null;
         }
     }

--- a/Scripts/Runtime/Core/ScriptableObjectCollectionItem.cs
+++ b/Scripts/Runtime/Core/ScriptableObjectCollectionItem.cs
@@ -58,16 +58,6 @@ namespace BrunoMikoski.ScriptableObjectCollections
                 return cachedIndex;
             }
         }
-        
-#if UNITY_EDITOR
-        private void OnValidate()
-        {
-            if (!guid.IsValid())
-            {
-                GenerateNewGUID();
-            }
-        }
-#endif
 
         public void SetCollection(ScriptableObjectCollection collection)
         {

--- a/Scripts/Runtime/Core/ScriptableObjectCollectionItem.cs
+++ b/Scripts/Runtime/Core/ScriptableObjectCollectionItem.cs
@@ -108,7 +108,7 @@ namespace BrunoMikoski.ScriptableObjectCollections
             ScriptableObjectCollectionItem other = o as ScriptableObjectCollectionItem;
             if (other == null)
                 return false;
-            
+
             return guid.IsValid() && other.guid.IsValid() && guid == other.guid;
         }
 
@@ -117,10 +117,12 @@ namespace BrunoMikoski.ScriptableObjectCollections
             if (ReferenceEquals(left, right))
                 return true;
 
-            if (ReferenceEquals(left, null))
-                return false;
-
-            if (ReferenceEquals(right, null))
+            // Use Unity's implicit bool to detect destroyed objects
+            bool leftNull = ReferenceEquals(left, null) || !(UnityEngine.Object)left;
+            bool rightNull = ReferenceEquals(right, null) || !(UnityEngine.Object)right;
+            if (leftNull && rightNull)
+                return true;
+            if (leftNull || rightNull)
                 return false;
 
             return left.Equals(right);


### PR DESCRIPTION
Key Changes

  1. New GUID Validation Processor

  - New file: SOCItemGuidProcessor.cs — Dedicated asset postprocessor for validating collection item GUIDs. Maintains an
   index of GUIDs to asset paths and ensures uniqueness on import. Replaces the GUID validation logic previously
  embedded in CollectionsAssetsPostProcessor.

  2. GUID Lookup Caching (Performance)

  - ScriptableObjectCollection.cs — Added itemGuidToScriptableObject dictionary for O(1) GUID-based item lookups instead
   of linear search. Cache is built alongside the name cache and cleared properly.
  - CollectionsRegistry.cs — Added collectionGuidLookup dictionary for fast collection retrieval by GUID. Rebuilt on
  register/unregister/reload.

  3. New Query Property Drawer

  - New file: CollectionItemQueryPropertyDrawer.cs — Full custom inspector for CollectionItemQuery<T> with foldout UI,
  rule editing, match type constraints, impossible-rule detection, and human-readable summaries.

  4. CollectionItemQuery Improvements

  - CollectionItemQuery.cs — Renamed enum values (NotAny → SomeNot, NotAll → None). Reduced GC allocations by reusing a
  targetGuids HashSet instead of creating new ones each call.

  5. CollectionItemIndirectReference Fixes

  - CollectionItemIndirectReference.cs — Fixed typo collectionLastKnowName → collectionLastKnownName (with
  FormerlySerializedAs for backward compat). Added hasCachedRef flag to prevent repeated resolution attempts on null
  refs.

  6. Code Generation Improvements

  - CodeGenerationUtility.cs — UTF-8 output without BOM. Handles both \r\n and \n line endings. Refactored base type
  detection logic for partial class generation.

  7. Editor UX Improvements

  - CollectionCustomEditor.cs — Robust UXML asset loading with error handling. Added DrawAdditionalIMGUI() extension
  point.
  - CollectionItemDropdown.cs — When item type has derived types, redirects to collection instead of immediately
  creating an item.
  - CollectionItemPickerPropertyDrawer.cs — Enhanced error logging with last known names and property paths.

  8. Bug Fixes & Cleanup

  - CollectionItemPicker.cs — Changed to reverse iteration for safe removal during enumeration.
  - ScriptableObjectCollectionItem.cs — Removed OnValidate() auto-GUID generation (now handled by the processor).
  Improved null/destroyed object equality checks.
  - CollectionsRegistry.cs — Refactored ValidateCollections() to validate items within collections using HashSets for
  duplicate detection. Fixed bidirectional type assignability check in GetCollectionsByItemType().
  - SOCSettings.cs — Fixed method name typo SetUsingBaseClassForItems → SetUseBaseClassForItems.
  - Typo fix across multiple files: IsKnowCollection → IsKnownCollection.